### PR TITLE
Feat: 카테고리 도메인 구현

### DIFF
--- a/src/main/java/techit/gongsimchae/domain/category/Category.java
+++ b/src/main/java/techit/gongsimchae/domain/category/Category.java
@@ -1,0 +1,22 @@
+package techit.gongsimchae.domain.category;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Category {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    @Column(unique = true)
+    private Long categoryNumber;
+
+    public Category (String name, Long categoryNumber){
+        this.name = name;
+        this.categoryNumber = categoryNumber;
+    }
+}

--- a/src/main/java/techit/gongsimchae/domain/category/entity/Category.java
+++ b/src/main/java/techit/gongsimchae/domain/category/entity/Category.java
@@ -1,4 +1,4 @@
-package techit.gongsimchae.domain.category;
+package techit.gongsimchae.domain.category.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/src/main/java/techit/gongsimchae/web/LoginController.java
+++ b/src/main/java/techit/gongsimchae/web/LoginController.java
@@ -46,7 +46,7 @@ public class LoginController {
 
         if (!joinDto.getPassword().equals(joinDto.getPasswordConfirm())) {
             bindingResult.reject("password_not_confirm", "비밀번호가 일치하지 않습니다.");
-            return "login/singup";
+            return "login/signup";
         }
         if (!userService.verifiedCode(joinDto.getEmail(), joinDto.getAuthCode())) {
             bindingResult.reject("authCode_invalid", "인증번호가 일치하지 않습니다.");

--- a/src/main/resources/static/css/category.css
+++ b/src/main/resources/static/css/category.css
@@ -1,0 +1,62 @@
+body {
+    font-family: Arial, sans-serif;
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin: 20px 0;
+}
+
+.category-alert {
+    font-size: 24px;
+    font-weight: bold;
+    margin-bottom: 10px;
+    text-align: center; /* 중앙 정렬 추가 */
+}
+
+.category-alert-cnt {
+    font-size: 14px;
+    margin-bottom: 10px;
+}
+
+.category-sort-standard-ul {
+    list-style-type: none;
+    padding: 0;
+    display: flex;
+    gap: 10px;
+}
+
+.category-sort-standard-li {
+    display: inline;
+}
+
+.category-sort-standard-alink {
+    text-decoration: none;
+    color: #aaa;
+    font-size: 14px;
+    transition: color 0.3s;
+}
+
+.category-sort-standard-alink:hover {
+    color: #000;
+}
+
+.perpendicular-divider {
+    text-decoration: none;
+    color: #aaa;
+    font-size: 14px;
+    transition: color 0.3s;
+    display: inline;
+    margin-left: 1rem;
+}
+
+.item-grid-view-main {
+    margin-top: 20px;
+    padding: 0 20px; /* 좌우 여백 추가 */
+    max-width: 1200px; /* 최대 너비 설정 */
+    margin-left: auto; /* 중앙 정렬 */
+    margin-right: auto; /* 중앙 정렬 */
+    box-sizing: border-box; /* 패딩과 테두리를 포함하여 요소 크기 계산 */
+}

--- a/src/main/resources/templates/category/category.html
+++ b/src/main/resources/templates/category/category.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>공심채 - 공구와 소분을 심플하게</title>
+    <link rel="stylesheet" href="/css/category.css">
+</head>
+<body>
+<div>네비게이션 바 들어갈 곳</div>
+<div>배너 추가된다면 들어갈 곳</div>
+<h3 class="category-alert">채소</h3>
+<div class="item-grid-view-main">
+    <div class="header">
+        <div class="category-alert-cnt">508건</div>
+        <ul class="category-sort-standard-ul">
+            <li class="category-sort-standard-li"><a href="/categories/907?page=1&amp;per_page=96&amp;sorted_type=0" class="category-sort-standard-alink">신상품순<p class="perpendicular-divider">|</p></a></li>
+            <li class="category-sort-standard-li"><a href="/categories/907?page=1&amp;per_page=96&amp;sorted_type=1" class="category-sort-standard-alink">판매량순<p class="perpendicular-divider">|</p></a></li>
+            <li class="category-sort-standard-li"><a href="/categories/907?page=1&amp;per_page=96&amp;sorted_type=5" class="category-sort-standard-alink">혜택순<p class="perpendicular-divider">|</p></a></li>
+            <li class="category-sort-standard-li"><a href="/categories/907?page=1&amp;per_page=96&amp;sorted_type=2" class="category-sort-standard-alink">낮은 가격순<p class="perpendicular-divider">|</p></a></li>
+            <li class="category-sort-standard-li"><a href="/categories/907?page=1&amp;per_page=96&amp;sorted_type=3" class="category-sort-standard-alink">높은 가격순</a></li>
+        </ul>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Overview

- 카테고리 엔티티 구현
- html, css 구현

## Change Log

- 뷰 제작 1차 완료
- singup -> signup 오타 수정

## To Reviewer

- 선택한 카테고리명과 신상품순, 높은 가격순, 낮은 가격순, 판매량순, 혜택순까지 구현
- 하단 그리드 뷰의 경우 @JungInGyu 님이 잘 구현하신 듯 하여 완성하시면 합치기로 했습니다.
- 팀 노션에 Pages에 코드, 설정, 파일에 데이터베이스를 추가해 두었습니다. 기본 카테고리 삽입 쿼리를 작성해 두었으니 각 DB에 일괄 실행 해 주세요
- @HeeJu0807 님 아이템 엔티티와 카테고리 엔티티 연관관계 추가해 주시면 될 것 같습니다.

## Issue Tags

- #
