### PR TITLE
Feat : 신상품 페이지 뷰, 기능, 정렬 추가

### DIFF
--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/repository/ItemRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/repository/ItemRepository.java
@@ -3,6 +3,7 @@ package techit.gongsimchae.domain.groupbuying.item.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import techit.gongsimchae.domain.groupbuying.category.entity.Category;
 import techit.gongsimchae.domain.groupbuying.item.entity.Item;
 
@@ -13,4 +14,32 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     List<Item> findTop8ByOrderByGroupBuyingQuantityDesc();
     List<Item> findAllByCategory(Category category);
     Page<Item> findAllByCategory(Category category, Pageable pageable);
+    Page<Item> findTop200ByOrderByCreateDateDesc(Pageable pageable);
+    @Query(
+            value = "SELECT * FROM (SELECT * FROM item ORDER BY create_date DESC LIMIT 200) sub ORDER BY cumulative_sales_volume DESC",
+            countQuery = "SELECT COUNT(*) FROM (SELECT * FROM item ORDER BY create_date DESC LIMIT 200) sub",
+            nativeQuery = true
+    )
+    Page<Item> findTop200ByCreateDateAndSortByCumulativeSalesVolumeDesc(Pageable pageable);
+
+    @Query(
+            value = "SELECT * FROM (SELECT * FROM item ORDER BY create_date DESC LIMIT 200) sub ORDER BY review_count DESC",
+            countQuery = "SELECT COUNT(*) FROM (SELECT * FROM item ORDER BY create_date DESC LIMIT 200) sub",
+            nativeQuery = true
+    )
+    Page<Item> findTop200ByCreateDateAndSortByReviewCountDesc(Pageable pageable);
+
+    @Query(
+            value = "SELECT * FROM (SELECT * FROM item ORDER BY create_date DESC LIMIT 200) sub ORDER BY original_price ASC",
+            countQuery = "SELECT COUNT(*) FROM (SELECT * FROM item ORDER BY create_date DESC LIMIT 200) sub",
+            nativeQuery = true
+    )
+    Page<Item> findTop200ByCreateDateAndSortByOriginalPriceAsc(Pageable pageable);
+
+    @Query(
+            value = "SELECT * FROM (SELECT * FROM item ORDER BY create_date DESC LIMIT 200) sub ORDER BY original_price DESC",
+            countQuery = "SELECT COUNT(*) FROM (SELECT * FROM item ORDER BY create_date DESC LIMIT 200) sub",
+            nativeQuery = true
+    )
+    Page<Item> findTop200ByCreateDateAndSortByOriginalPriceDesc(Pageable pageable);
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemService.java
@@ -88,6 +88,7 @@ public class ItemService {
         return itemRepository.findAllByCategory(category);
     }
 
+    @Transactional(readOnly = true)
     public Page<Item> getItemsPageByCategory(Category category, Integer page, Integer per_page,
                                                    Integer sorted_type){
         SortType sortType = getInstanceByTypeNumber(sorted_type);
@@ -97,14 +98,35 @@ public class ItemService {
         } else if (sortType.equals(판매량순)) {
             pageable = PageRequest.of(page, per_page, Sort.by(Direction.DESC, "cumulativeSalesVolume"));
         } else if (sortType.equals(리뷰많은순)){
-            pageable = PageRequest.of(page, per_page, Sort.by(Direction.DESC, "reviewCount").descending());
+            pageable = PageRequest.of(page, per_page, Sort.by(Direction.DESC, "reviewCount"));
         } else if (sortType.equals(낮은가격순)){
-            pageable = PageRequest.of(page, per_page, Sort.by(Direction.ASC, "originalPrice").ascending());
+            pageable = PageRequest.of(page, per_page, Sort.by(Direction.ASC, "originalPrice"));
         } else if (sortType.equals(높은가격순)) {
-            pageable = PageRequest.of(page, per_page, Sort.by(Direction.DESC, "originalPrice").descending());
+            pageable = PageRequest.of(page, per_page, Sort.by(Direction.DESC, "originalPrice"));
         } else {
             throw new CustomWebException("존재하지 않는 정렬기준입니다.");
         }
         return itemRepository.findAllByCategory(category, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Item> getTop200ItemsPage(Integer page, Integer per_page, Integer sorted_type) {
+        SortType sortType = getInstanceByTypeNumber(sorted_type);
+        Pageable pageable = PageRequest.of(page, per_page);
+        Page<Item> newItemsPage;
+        if (sortType.equals(신상품순)){
+            newItemsPage = itemRepository.findTop200ByOrderByCreateDateDesc(pageable);
+        } else if (sortType.equals(판매량순)) {
+            newItemsPage = itemRepository.findTop200ByCreateDateAndSortByCumulativeSalesVolumeDesc(pageable);
+        } else if (sortType.equals(리뷰많은순)){
+            newItemsPage = itemRepository.findTop200ByCreateDateAndSortByReviewCountDesc(pageable);
+        } else if (sortType.equals(낮은가격순)){
+            newItemsPage = itemRepository.findTop200ByCreateDateAndSortByOriginalPriceAsc(pageable);
+        } else if (sortType.equals(높은가격순)) {
+            newItemsPage = itemRepository.findTop200ByCreateDateAndSortByOriginalPriceDesc(pageable);
+        } else {
+            throw new CustomWebException("존재하지 않는 정렬기준입니다.");
+        }
+        return newItemsPage;
     }
 }

--- a/src/main/java/techit/gongsimchae/web/ItemController.java
+++ b/src/main/java/techit/gongsimchae/web/ItemController.java
@@ -84,4 +84,17 @@ public class ItemController {
         model.addAttribute("itemsPage", itemsPage);
         return "/category/category";
     }
+
+    /**
+     * 상품 등록일 기준 200건을 조회
+     * 200건 내에서 sorted_type에 따라 정렬을 다르게 리턴
+     */
+    @GetMapping("/collection-groups/new-item")
+    public String getNewItems(@RequestParam(defaultValue = "1") Integer page,
+                              @RequestParam(defaultValue = "96") Integer per_page,
+                              @RequestParam(defaultValue = "1") Integer sorted_type, Model model){
+        Page<Item> newItemsPage = itemService.getTop200ItemsPage(page - 1, per_page, sorted_type);
+        model.addAttribute("newItemsPage", newItemsPage);
+        return "category/newItem";
+    }
 }

--- a/src/main/resources/templates/category/newItem.html
+++ b/src/main/resources/templates/category/newItem.html
@@ -1,0 +1,49 @@
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout/productHeader :: header(~{::title},~{::section})}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>공심채</title>
+    <link rel="stylesheet" href="/css/category.css">
+</head>
+<body>
+<section>
+    <h1 class="category-alert">신상품</h1>
+    <div class="item-grid-view-main">
+        <div class="header">
+            <div class="category-alert-cnt" th:text="'총 ' + ${newItemsPage.numberOfElements} + '건'"></div>
+            <ul class="category-sort-standard-ul">
+                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/new-item(page=1, per_page=96, sorted_type=1)}" class="category-sort-standard-alink">신상품순<p class="perpendicular-divider">|</p></a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/new-item(page=1, per_page=96, sorted_type=2)}"  class="category-sort-standard-alink">판매량순<p class="perpendicular-divider">|</p></a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/new-item(page=1, per_page=96, sorted_type=3)}"  class="category-sort-standard-alink">리뷰 많은 순<p class="perpendicular-divider">|</p></a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/new-item(page=1, per_page=96, sorted_type=4)}"  class="category-sort-standard-alink">낮은 가격순<p class="perpendicular-divider">|</p></a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/new-item(page=1, per_page=96, sorted_type=5)}"  class="category-sort-standard-alink">높은 가격순</a></li>
+            </ul>
+        </div>
+    </div>
+</section>
+
+<section class="product-section">
+    <div class="product-list">
+        <div th:each="item : ${newItemsPage}" class="product-item">
+            <div class="product-image-placeholder">[상품 이미지]</div>
+            <button class="add-to-cart" data-item-id="[[${item.id}]]">
+                <i class="fa fa-shopping-cart"></i> 장바구니에 담기
+            </button>
+            <h3 class="item-name" th:text="${item.name}">상품명</h3>
+            <div class="price-container">
+                <span class="original-price" th:text="${#numbers.formatDecimal(item.originalPrice, 0, 'COMMA', 0, 'POINT')} + '원'">원래 가격</span>
+                <div class="discount-container">
+                    <span class="discount-rate" th:text="${item.discountRate} + '%'">할인율</span>
+                    <span class="discount-price"
+                          th:with="discountPrice=${item.originalPrice * (100 - item.discountRate) / 100}"
+                          th:text="${#numbers.formatDecimal(discountPrice, 0, 'COMMA', 0, 'POINT')} + '원'">할인 가격</span>
+                    <span class="buying-people" th:text="${item.groupBuyingQuantity} + '명 구매중'">구매 인원</span>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+</body>
+</html>

--- a/src/main/resources/templates/layout/navbar.html
+++ b/src/main/resources/templates/layout/navbar.html
@@ -49,7 +49,7 @@
             </ul>
         </div>
         <div class="d-flex justify-content-center mt-2">
-            <a th:href="@{/product/martket-newProduct}" class="btn btn-link nav-list-a">신상품</a>
+            <a th:href="@{/collection-groups/new-item}" class="btn btn-link nav-list-a">신상품</a>
             <a th:href="@{/product/market-best}" class="btn btn-link nav-list-a">베스트</a>
             <a th:href="@{/market-benefit}" class="btn btn-link nav-list-a">이벤트</a>
         </div>


### PR DESCRIPTION
## Overview

- 신상품 페이지 완료했습니다.

## Change Log

- 페이지네이션을 해서 반환 중인데, 1페이지당 96개까지 허용하기 때문에 더미 데이터를 많이 넣어도 총 검색 수는 96을 넘지 않는 상태입니다.
- 이 페이지네이션과 각종 조회 관련 기능은 추후에 queryDsl 추가 시 변경될 예정이라 일단 간단하게 반환하도록 둔 상태입니다.
- 더미 데이터 넣는 procedure를 노션에 추가해 두었습니다. 테스트를 위해 채소 더미 데이터 200개를 삽입하는 procedure이니 참고하셔서 더미 데이터가 필요하시면 순서를 보고 삽입해 주시면 될 것 같습니다.
- repository에 쿼리가 서브 쿼리와 페이지네이션을 위한 카운트 쿼리가 들어가 조금 복잡한데, 마찬가지로 queryDsl를 적용해  동적 쿼리로 만들어 하나의 쿼리로 합칠 예정이니 이 부분은 가볍게 봐 주세요.

## To Reviewer

-

## Issue Tags

- #
