### PR TITLE
Feat: 이벤트 삭제 기능 추가

### DIFF
--- a/src/main/java/techit/gongsimchae/domain/common/imagefile/entity/ImageFile.java
+++ b/src/main/java/techit/gongsimchae/domain/common/imagefile/entity/ImageFile.java
@@ -1,12 +1,17 @@
 package techit.gongsimchae.domain.common.imagefile.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import techit.gongsimchae.domain.BaseEntity;
 import techit.gongsimchae.domain.common.user.entity.User;
-import techit.gongsimchae.domain.groupbuying.coupon.entity.Coupon;
 import techit.gongsimchae.domain.groupbuying.event.entity.Event;
 import techit.gongsimchae.domain.groupbuying.item.entity.Item;
 import techit.gongsimchae.domain.groupbuying.post.entity.Post;
@@ -23,6 +28,7 @@ public class ImageFile extends BaseEntity {
 
     private String originalFilename;
     private String storeFilename;
+    private Integer imageFileStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -37,10 +43,6 @@ public class ImageFile extends BaseEntity {
     private Item item;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "coupon_id")
-    private Coupon coupon;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")
     private Event event;
 
@@ -52,35 +54,38 @@ public class ImageFile extends BaseEntity {
         this.originalFilename = originalFilename;
         this.storeFilename = storeFilename;
         this.user = user;
+        this.imageFileStatus = 0;
     }
 
     public ImageFile(String originalFilename, String storeFilename, Post post) {
         this.originalFilename = originalFilename;
         this.storeFilename = storeFilename;
         this.post = post;
+        this.imageFileStatus = 0;
     }
 
     public ImageFile(String originalFilename, String storeFilename, Item item) {
         this.originalFilename = originalFilename;
         this.storeFilename = storeFilename;
         this.item = item;
+        this.imageFileStatus = 0;
     }
 
     public ImageFile(String originalFilename, String storeFilename, Subdivision subdivision) {
         this.originalFilename = originalFilename;
         this.storeFilename = storeFilename;
         this.subdivision = subdivision;
-    }
-
-    public ImageFile(String originalFilename, String storeFilename, Coupon coupon) {
-        this.originalFilename = originalFilename;
-        this.storeFilename = storeFilename;
-        this.coupon = coupon;
+        this.imageFileStatus = 0;
     }
 
     public ImageFile(String originalFilename, String storeFilename, Event event) {
         this.originalFilename = originalFilename;
         this.storeFilename = storeFilename;
         this.event = event;
+        this.imageFileStatus = 0;
+    }
+
+    public void setStatusDeleted(){
+        this.imageFileStatus = 1;
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/common/imagefile/repository/ImageFileRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/common/imagefile/repository/ImageFileRepository.java
@@ -1,14 +1,14 @@
 package techit.gongsimchae.domain.common.imagefile.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import techit.gongsimchae.domain.common.imagefile.entity.ImageFile;
-import techit.gongsimchae.domain.groupbuying.coupon.entity.Coupon;
 import techit.gongsimchae.domain.groupbuying.event.entity.Event;
 
 @Repository
 public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
-
-    ImageFile findByCoupon(Coupon coupon);
     ImageFile findByEvent(Event event);
+
+    List<ImageFile> findALlByEventId(Long eventId);
 }

--- a/src/main/java/techit/gongsimchae/domain/common/imagefile/service/ImageS3Service.java
+++ b/src/main/java/techit/gongsimchae/domain/common/imagefile/service/ImageS3Service.java
@@ -2,6 +2,10 @@ package techit.gongsimchae.domain.common.imagefile.service;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,17 +16,11 @@ import techit.gongsimchae.domain.common.imagefile.entity.ImageFile;
 import techit.gongsimchae.domain.common.imagefile.repository.ImageFileRepository;
 import techit.gongsimchae.domain.common.user.entity.User;
 import techit.gongsimchae.domain.common.user.repository.UserRepository;
-import techit.gongsimchae.domain.groupbuying.coupon.entity.Coupon;
 import techit.gongsimchae.domain.groupbuying.event.entity.Event;
 import techit.gongsimchae.domain.groupbuying.item.entity.Item;
 import techit.gongsimchae.domain.groupbuying.post.entity.Post;
 import techit.gongsimchae.domain.portion.subdivision.entity.Subdivision;
 import techit.gongsimchae.global.exception.CustomWebException;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
 
 @Service
 @Slf4j
@@ -74,9 +72,7 @@ public class ImageS3Service {
                 imageFile = new ImageFile(originalFilename, getFullPath(directory, storeFileName), (Subdivision) object);
             } else if (object instanceof User) {
                 imageFile = new ImageFile(originalFilename, getFullPath(directory, storeFileName), (User) object);
-            } else if (object instanceof Coupon) {
-                imageFile = new ImageFile(originalFilename, getFullPath(directory, storeFileName), (Coupon) object);
-            } else if (object instanceof Event) {
+            }  else if (object instanceof Event) {
                 imageFile = new ImageFile(originalFilename, getFullPath(directory, storeFileName), (Event) object);
             } else {
                 throw new CustomWebException("이미지를 저장할 수 없는 객체입니다.");
@@ -121,5 +117,13 @@ public class ImageS3Service {
         } catch (Exception e) {
             throw new CustomWebException(e.getMessage());
         }
+    }
+
+    /**
+     * 실제 삭제가 아닌 deleteStatus를 1로 변경하는 메서드
+     */
+    public void deleteImageFile(Long eventId) {
+        List<ImageFile> imageFiles = imageFileRepository.findALlByEventId(eventId);
+        imageFiles.forEach(ImageFile::setStatusDeleted);
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/category/service/CategoryService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/category/service/CategoryService.java
@@ -2,15 +2,28 @@ package techit.gongsimchae.domain.groupbuying.category.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import techit.gongsimchae.domain.groupbuying.category.entity.Category;
-import techit.gongsimchae.domain.groupbuying.category.repository.CategoryRepository;import techit.gongsimchae.domain.groupbuying.category.entity.Category;
+import techit.gongsimchae.domain.groupbuying.category.repository.CategoryRepository;
 
 import java.util.List;
+import techit.gongsimchae.domain.groupbuying.event.entity.Event;
+import techit.gongsimchae.domain.groupbuying.event.repository.EventRepository;
+import techit.gongsimchae.domain.groupbuying.eventcategory.entity.EventCategory;
+import techit.gongsimchae.domain.groupbuying.eventcategory.repository.EventCategoryRepository;
+import techit.gongsimchae.domain.groupbuying.item.entity.Item;
+import techit.gongsimchae.domain.groupbuying.item.repository.ItemRepository;
+import techit.gongsimchae.global.exception.CustomWebException;
+import techit.gongsimchae.global.message.ErrorMessage;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class CategoryService {
     private final CategoryRepository categoryRepository;
+    private final EventCategoryRepository eventCategoryRepository;
+    private final ItemRepository itemRepository;
+    private final EventRepository eventRepository;
 
     // 모든 카테고리 조회
     public List<Category> getAllCategories() {
@@ -20,5 +33,17 @@ public class CategoryService {
     // 카테고리 ID로 조회
     public Category getCategoryById(Long id) {
         return categoryRepository.findById(id).orElse(null);
+    }
+
+    public void endCategoryEvent(Long eventId) {
+        Event event = eventRepository.findById(eventId).orElseThrow(
+                () -> new CustomWebException(ErrorMessage.EVENT_NOT_FOUND)
+        );
+        List<EventCategory> eventCategories = eventCategoryRepository.findAllByEventId(eventId);
+        for (EventCategory eventCategory : eventCategories) {
+            Category category = eventCategory.getCategory();
+            List<Item> items = itemRepository.findAllByCategory(category);
+            items.forEach((element) -> element.minusDiscountRate(event.getDiscountRate()));
+        }
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/coupon/dto/CouponRespDtoWeb.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/coupon/dto/CouponRespDtoWeb.java
@@ -1,12 +1,10 @@
 package techit.gongsimchae.domain.groupbuying.coupon.dto;
 
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import techit.gongsimchae.domain.common.imagefile.entity.ImageFile;
 import techit.gongsimchae.domain.groupbuying.coupon.entity.Coupon;
-
-import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/coupon/entity/Coupon.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/coupon/entity/Coupon.java
@@ -28,6 +28,7 @@ public class Coupon {
     private LocalDateTime expirationDate;
     private String couponName;
     private String couponCode; // 쿠폰등록 번호
+    private Integer couponStatus;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")
@@ -43,6 +44,7 @@ public class Coupon {
         this.expirationDate = dto.getExpirationDate();
         this.couponName = dto.getCouponName();
         this.couponCode = dto.getCouponCode();
+        this.couponStatus = 0;
     }
 
     public Coupon(EventCreateReqDtoWeb eventDto){
@@ -51,9 +53,14 @@ public class Coupon {
         this.expirationDate = eventDto.getExpirationDate();
         this.couponName = eventDto.getCouponName();
         this.couponCode = eventDto.getCouponCode();
+        this.couponStatus = 0;
     }
 
     public void connectEvent(Event event){
         this.event = event;
+    }
+
+    public void setStatusDeleted(){
+        this.couponStatus = 1;
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/coupon/repository/CouponRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/coupon/repository/CouponRepository.java
@@ -1,5 +1,6 @@
 package techit.gongsimchae.domain.groupbuying.coupon.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import techit.gongsimchae.domain.groupbuying.coupon.entity.Coupon;
 
@@ -10,4 +11,5 @@ public interface CouponRepository extends JpaRepository<Coupon, Long>, CouponCus
 
     Optional<Coupon> findByCouponCode(String couponCode);
     Optional<Coupon> findByEvent(Event event);
+    List<Coupon> findAllByEventId(Long eventId);
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/coupon/service/CouponService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/coupon/service/CouponService.java
@@ -50,7 +50,7 @@ public class CouponService {
         }
     }
 
-    public List<EventResAdminDtoWeb> getEventInfo(List<Event> events) {
+    public List<EventResAdminDtoWeb> getCouponEventInfo(List<Event> events) {
         List<EventResAdminDtoWeb> eventResAdminDtoWebs = new ArrayList<>();
         String couponCode;
         for (Event event : events) {

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/coupon/service/CouponService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/coupon/service/CouponService.java
@@ -60,4 +60,9 @@ public class CouponService {
         }
         return eventResAdminDtoWebs;
     }
+
+    public void deleteCoupon(Long eventId) {
+        List<Coupon> coupons = couponRepository.findAllByEventId(eventId);
+        coupons.forEach(Coupon::setStatusDeleted);
+    }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/couponuser/entity/CouponUser.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/couponuser/entity/CouponUser.java
@@ -35,4 +35,8 @@ public class CouponUser {
     public void addCoupon(Coupon coupon) {
         this.coupon = coupon;
     }
+
+    public void setStatusDeleted() {
+        this.couponStatus = 1;
+    }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/couponuser/repository/CouponUserRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/couponuser/repository/CouponUserRepository.java
@@ -1,7 +1,10 @@
 package techit.gongsimchae.domain.groupbuying.couponuser.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import techit.gongsimchae.domain.groupbuying.coupon.entity.Coupon;
 import techit.gongsimchae.domain.groupbuying.couponuser.entity.CouponUser;
 
 public interface CouponUserRepository extends JpaRepository<CouponUser,Long> {
+    List<CouponUser> findAllByCouponIn(List<Coupon> coupons);
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/couponuser/service/CouponUserService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/couponuser/service/CouponUserService.java
@@ -1,0 +1,26 @@
+package techit.gongsimchae.domain.groupbuying.couponuser.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import techit.gongsimchae.domain.groupbuying.coupon.entity.Coupon;
+import techit.gongsimchae.domain.groupbuying.coupon.repository.CouponRepository;
+import techit.gongsimchae.domain.groupbuying.couponuser.entity.CouponUser;
+import techit.gongsimchae.domain.groupbuying.couponuser.repository.CouponUserRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CouponUserService {
+
+    private final CouponRepository couponRepository;
+    private final CouponUserRepository couponUserRepository;
+
+    public void deleteCouponUser(Long eventId){
+        List<Coupon> coupons = couponRepository.findAllByEventId(eventId);
+        List<CouponUser> couponUsers = couponUserRepository.findAllByCouponIn(coupons);
+        couponUsers.forEach(CouponUser::setStatusDeleted);
+    }
+
+}

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/event/dto/EventResAdminDtoWeb.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/event/dto/EventResAdminDtoWeb.java
@@ -17,6 +17,7 @@ public class EventResAdminDtoWeb {
     private LocalDateTime expirationDate;
     private Long eventId;
     private String couponCode;
+    private Integer eventStatus;
 
     public EventResAdminDtoWeb(Event event, String couponCode){
         this.eventType = event.getEventType();
@@ -26,5 +27,6 @@ public class EventResAdminDtoWeb {
         this.expirationDate = event.getExpirationDate();
         this.eventId = event.getId();
         this.couponCode = couponCode;
+        this.eventStatus = event.getEventStatus();
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/event/entity/Event.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/event/entity/Event.java
@@ -28,6 +28,7 @@ public class Event {
     private Integer discountRate;
     private Integer maxDiscount;
     private LocalDateTime expirationDate;
+    private Integer eventStatus;
 
     public Event(EventCreateReqDtoWeb dto){
         this.eventType = EventType.getInstanceByEventTypeName(dto.getEventTypeName());
@@ -35,5 +36,10 @@ public class Event {
         this.discountRate = dto.getDiscountRate();
         this.maxDiscount = dto.getMaxDiscount();
         this.expirationDate = dto.getExpirationDate();
+        this.eventStatus = 0;
+    }
+
+    public void setStatusDeleted() {
+        this.eventStatus = 1;
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/event/repository/EventRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/event/repository/EventRepository.java
@@ -7,5 +7,8 @@ import techit.gongsimchae.domain.groupbuying.event.entity.Event;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
     Event findByEventName(String eventName);
-    List<Event> findByExpirationDateAfter(LocalDateTime localDateTime);
+    List<Event> findByExpirationDateAfterAndEventStatusEquals(LocalDateTime localDateTime, Integer eventStatus);
+
+    List<Event> findAllByEventStatus(Integer eventStatus);
+    List<Event> findAllByOrderByEventStatusAscExpirationDateAsc();
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/event/service/EventService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/event/service/EventService.java
@@ -40,7 +40,7 @@ public class EventService {
         List<Category> categories = categoryRepository.findAllByNameIn(eventDto.getCategoryNames());
         List<Item> categoryItems = itemRepository.findAllByCategoryIn(categories);
         for (Item categoryItem : categoryItems) {
-            categoryItem.updateDiscountRate(eventDto.getDiscountRate());
+            categoryItem.plusDiscountRate(eventDto.getDiscountRate());
         }
         Event event = eventRepository.save(new Event(eventDto));
         for (Category category : categories) {

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/event/service/EventService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/event/service/EventService.java
@@ -20,6 +20,7 @@ import techit.gongsimchae.domain.groupbuying.item.entity.Item;
 import techit.gongsimchae.domain.groupbuying.item.repository.ItemRepository;
 import techit.gongsimchae.global.exception.CustomWebException;
 import techit.gongsimchae.global.message.ErrorMessage;
+import techit.gongsimchae.global.util.EntityStatus;
 
 @Service
 @Transactional
@@ -69,12 +70,12 @@ public class EventService {
     }
 
     public List<Event> getAllEvents() {
-        List<Event> events = eventRepository.findAll();
-        return eventRepository.findAll();
+        return eventRepository.findAllByOrderByEventStatusAscExpirationDateAsc();
     }
 
-    public List<EventResUserDtoWeb> getEvents(){
-        List<Event> activatedEvents = eventRepository.findByExpirationDateAfter(LocalDateTime.now());
+    public List<EventResUserDtoWeb> getActivatedEvents(){
+        List<Event> activatedEvents = eventRepository.findByExpirationDateAfterAndEventStatusEquals(LocalDateTime.now(),
+                EntityStatus.EXIST);
         List<EventResUserDtoWeb> eventResAdminDtoWebs = new ArrayList<>();
         for (Event activatedEvent : activatedEvents) {
             eventResAdminDtoWebs.add(new EventResUserDtoWeb(activatedEvent, imageFileRepository.findByEvent(activatedEvent).getStoreFilename()));

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/event/service/EventService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/event/service/EventService.java
@@ -81,4 +81,20 @@ public class EventService {
         }
         return eventResAdminDtoWebs;
     }
+
+    public void deleteEvent(Long eventId) {
+        /**
+         * 1. event의 eventStatus를 1로 변경
+         * 2. eventCategory에서 eventStatus가 1로 변경된 eventId를 가진 eventCategory 인스턴스의 eventCategoryStatus 를 1로 변경
+         * 3. coupon에서 eventStatus가 1로 변경된 eventId를 가진 coupon의 couponStatus를 1로 변경
+         * 4. couponUser에서 couponStatus가 1로 변경된 couponId를 가진 couponUser의 couponUserStatus를 1로 변경
+         * 5. imageFile에서 eventStatus가 1로 변경된 eventId를 가진 ImageFile 인스턴스의 ImageFileStatus를 1로 변경
+         */
+        Event event = eventRepository.findById(eventId).orElseThrow(
+                () -> new CustomWebException(ErrorMessage.EVENT_NOT_FOUND)
+        );
+        event.setStatusDeleted();
+
+
+    }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/eventcategory/entity/EventCategory.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/eventcategory/entity/EventCategory.java
@@ -19,14 +19,19 @@ public class EventCategory {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @ManyToOne(cascade = CascadeType.REMOVE)
+    private Integer eventCategoryStatus;
+    @ManyToOne
     private Event event;
     @ManyToOne
     private Category category;
 
     public EventCategory(Event event, Category category) {
+        this.eventCategoryStatus = 0;
         this.event = event;
         this.category = category;
+    }
+
+    public void setStatusDeleted(){
+        this.eventCategoryStatus = 1;
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/eventcategory/repository/EventCategoryRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/eventcategory/repository/EventCategoryRepository.java
@@ -1,8 +1,11 @@
 package techit.gongsimchae.domain.groupbuying.eventcategory.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import techit.gongsimchae.domain.groupbuying.eventcategory.entity.EventCategory;
 
 public interface EventCategoryRepository extends JpaRepository<EventCategory, Long> {
     void deleteAllByEventId(Long eventId);
+
+    List<EventCategory> findAllByEventId(Long eventId);
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/eventcategory/service/EventCategoryService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/eventcategory/service/EventCategoryService.java
@@ -1,4 +1,21 @@
 package techit.gongsimchae.domain.groupbuying.eventcategory.service;
 
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import techit.gongsimchae.domain.groupbuying.eventcategory.entity.EventCategory;
+import techit.gongsimchae.domain.groupbuying.eventcategory.repository.EventCategoryRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
 public class EventCategoryService {
+
+    private final EventCategoryRepository eventCategoryRepository;
+
+    public void deleteEventCategory(Long eventId) {
+        List<EventCategory> eventCategories = eventCategoryRepository.findAllByEventId(eventId);
+        eventCategories.forEach(EventCategory::setStatusDeleted);
+    }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/entity/Item.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/entity/Item.java
@@ -66,7 +66,11 @@ public class Item extends BaseEntity {
         this.category = category;
     }
 
-    public void updateDiscountRate(Integer discountRate) {
+    public void plusDiscountRate(Integer discountRate) {
         this.discountRate += discountRate;
+    }
+
+    public void minusDiscountRate(Integer discountRate) {
+        this.discountRate -= discountRate;
     }
 }

--- a/src/main/java/techit/gongsimchae/global/message/ErrorMessage.java
+++ b/src/main/java/techit/gongsimchae/global/message/ErrorMessage.java
@@ -14,6 +14,7 @@ public interface ErrorMessage {
     String EVENT_TYPE_NOT_VALID = "유효하지 않은 이벤트 타입입니다.";
     String CATEGORY_NAME_NOT_VALID = "유효하지 않은 카테고리 이름입니다.";
     String EVENT_BANNER_IMAGE_EMPTY = "이벤트 배너 이미지가 존재하지 않습니다.";
+    String EVENT_NOT_FOUND = "이벤트가 존재하지 않습니다.";
 
     /**
      * portion 에러

--- a/src/main/java/techit/gongsimchae/global/util/EntityStatus.java
+++ b/src/main/java/techit/gongsimchae/global/util/EntityStatus.java
@@ -1,0 +1,6 @@
+package techit.gongsimchae.global.util;
+
+public interface EntityStatus {
+    Integer DELETED = 1;
+    Integer EXIST = 0;
+}

--- a/src/main/java/techit/gongsimchae/web/EventController.java
+++ b/src/main/java/techit/gongsimchae/web/EventController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import techit.gongsimchae.domain.common.imagefile.service.ImageS3Service;
+import techit.gongsimchae.domain.groupbuying.category.service.CategoryService;
 import techit.gongsimchae.domain.groupbuying.coupon.service.CouponService;
 import techit.gongsimchae.domain.groupbuying.couponuser.service.CouponUserService;
 import techit.gongsimchae.domain.groupbuying.event.dto.EventCreateReqDtoWeb;
@@ -42,6 +43,7 @@ public class EventController {
     private final EventCategoryService eventCategoryService;
     private final ImageS3Service imageS3Service;
     private final CouponUserService couponUserService;
+    private final CategoryService categoryService;
 
 
     //--------------------------------------------- event --------------------------------------------
@@ -110,16 +112,20 @@ public class EventController {
     public String deleteEvent(@RequestParam("event_id") Long eventId){
         /**
          * 1. imageFile에서 eventStatus가 1로 변경된 eventId를 가진 ImageFile 인스턴스의 ImageFileStatus를 1로 변경
-         * 2. eventCategory에서 eventStatus가 1로 변경된 eventId를 가진 eventCategory 인스턴스의 eventCategoryStatus 를 1로 변경
-         * 3. couponUser에서 couponStatus가 1로 변경된 couponId를 가진 couponUser의 couponUserStatus를 1로 변경
-         * 4. coupon에서 eventStatus가 1로 변경된 eventId를 가진 coupon의 couponStatus를 1로 변경
-         * 5. event의 eventStatus를 1로 변경
+         * 2. item에서 eventCategory에서 eventStatus가 1로 변경된 eventId를 가진 Category의 categoryId를 가진 Item의 할인가를
+         *    event의 discountRate만큼 감소
+         * 3. eventCategory에서 eventStatus가 1로 변경된 eventId를 가진 eventCategory 인스턴스의 eventCategoryStatus 를 1로 변경
+         * 4. couponUser에서 couponStatus가 1로 변경된 couponId를 가진 couponUser의 couponUserStatus를 1로 변경
+         * 5. coupon에서 eventStatus가 1로 변경된 eventId를 가진 coupon의 couponStatus를 1로 변경
+         * 6. event의 eventStatus를 1로 변경
          */
         imageS3Service.deleteImageFile(eventId);
+        categoryService.endCategoryEvent(eventId);
         eventCategoryService.deleteEventCategory(eventId);
         couponUserService.deleteCouponUser(eventId);
         couponService.deleteCoupon(eventId);
         eventService.deleteEvent(eventId);
+
         return "redirect:/admin/event";
     }
 }

--- a/src/main/java/techit/gongsimchae/web/EventController.java
+++ b/src/main/java/techit/gongsimchae/web/EventController.java
@@ -52,7 +52,7 @@ public class EventController {
      */
     @GetMapping("/event")
     public String getEventPage(Model model){
-        List<EventResUserDtoWeb> eventResUserDtoWebs = eventService.getEvents();
+        List<EventResUserDtoWeb> eventResUserDtoWebs = eventService.getActivatedEvents();
         model.addAttribute("events", eventResUserDtoWebs);
         return "/category/event";
     }
@@ -75,7 +75,7 @@ public class EventController {
     @GetMapping("/admin/event")
     public String getEventList(Model model){
         List<Event> events = eventService.getAllEvents();
-        List<EventResAdminDtoWeb> eventResAdminDtoWebs = couponService.getEventInfo(events);
+        List<EventResAdminDtoWeb> eventResAdminDtoWebs = couponService.getCouponEventInfo(events);
         model.addAttribute("events", eventResAdminDtoWebs);
         return "admin/event/event";
     }

--- a/src/main/resources/templates/admin/event/event.html
+++ b/src/main/resources/templates/admin/event/event.html
@@ -26,6 +26,7 @@
                 <th>최대할인금액</th>
                 <th>만료기한</th>
                 <th>쿠폰코드</th>
+                <th>상태</th>
                 <th>삭제</th>
             </tr>
             </thead>
@@ -37,6 +38,7 @@
                 <td th:text="${event.maxDiscount}"></td>
                 <td th:text="${#temporals.format(event.expirationDate,'yyyy-MM-dd HH:mm:ss')}"></td>
                 <td th:text="${event.couponCode}"></td>
+                <td th:text="${event.eventStatus == 1 ? '종료' : '진행중'}"></td>
                 <td>
                     <form th:action="@{/admin/event/delete}" method="post">
                         <input type="hidden" th:value="${event.getEventId()}" th:name="event_id"/>


### PR DESCRIPTION
## Overview

- 이벤트 삭제 기능이 동작하도록 기능 구현

## Change Log

- 이벤트 연관 엔티티들의 status를 1로 변경하여 구현
- 조회 시 status가 1인 객체는 조회하지 않도록 변경
- 관리자 페이지에서는 종료 | 진행중으로 조회
- 삭제된 이벤트는 유저 페이지에서 조회되지 않도록 기능 추가
- 이벤트 삭제 시 해당 카테고리의 아이템 엔티티의 discountRate를 감소시켜 이벤트 종료 반영

## To Reviewer

-

## Issue Tags

- #
