### PR TITLE
Config: build.gradle에 서브모듈의 파일 가져오는 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,3 +60,11 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+task copyYML(type: Copy){
+	copy {
+		from './gongsimchae_yml'
+		include "*.yml"
+		into './src/main/resources'
+	}
+}


### PR DESCRIPTION
## Overview

- 서버에서 빌드 후 배포 및 실행 될 때 서브모듈에 있는 yml 파일들을 가져오기 위해 추가한 설정입니다.

## Change Log

-

## To Reviewer

-

## Issue Tags

- #
