### PR TITLE
Config: 메인브랜치에서는 카프카 접속할때 로컬이 아니라 카프카 서버에 접속할 수 있도록 재설정

### DIFF
--- a/src/main/java/techit/gongsimchae/global/config/fafka/KafkaConstants.java
+++ b/src/main/java/techit/gongsimchae/global/config/fafka/KafkaConstants.java
@@ -6,6 +6,6 @@ public class KafkaConstants {
     public static final String KAFKA_AI_TOPIC = "chat-ai-topic";
     public static final String KAFKA_TOPIC = "chat-topic";
     public static final String GROUP_ID = "chat-group";
-    public static final String KAFKA_BROKER = "localhost:9092";
+    public static final String KAFKA_BROKER = "13.125.196.230:9092";
     public static List<Integer> partitionList;
 }


### PR DESCRIPTION
## Overview

- Config: 메인브랜치에서는 카프카 접속할때 로컬이 아니라 카프카 서버에 접속할 수 있도록 재설정

## Change Log

-

## To Reviewer

-

## Issue Tags

- #
