### PR TITLE
Config : 카프카 브로커 아이피 로컬호스트가 아닌 카프카 서버 아이피로 재설정

### DIFF
--- a/src/main/java/techit/gongsimchae/global/config/fafka/KafkaConsumerConfig.java
+++ b/src/main/java/techit/gongsimchae/global/config/fafka/KafkaConsumerConfig.java
@@ -5,6 +5,7 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
@@ -23,6 +24,9 @@ import java.util.*;
 @Slf4j
 public class KafkaConsumerConfig {
 
+    @Value("${spring.kafka.producer.bootstrap-servers}")
+    private String kafkaBroker;
+
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, ChatMessageDto> kafkaListenerContainerFactory() {
         ConcurrentKafkaListenerContainerFactory<String, ChatMessageDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
@@ -38,7 +42,7 @@ public class KafkaConsumerConfig {
         JsonDeserializer<ChatMessageDto> deserializer = new JsonDeserializer<>(ChatMessageDto.class);
         deserializer.addTrustedPackages("*");
 
-        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaConstants.KAFKA_BROKER);
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBroker);
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializer);
         config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");

--- a/src/main/java/techit/gongsimchae/global/config/fafka/KafkaProducerConfig.java
+++ b/src/main/java/techit/gongsimchae/global/config/fafka/KafkaProducerConfig.java
@@ -2,6 +2,7 @@ package techit.gongsimchae.global.config.fafka;
 
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
@@ -18,6 +19,9 @@ import java.util.Map;
 @EnableKafka
 public class KafkaProducerConfig {
 
+    @Value("${spring.kafka.producer.bootstrap-servers}")
+    private String kafkaBroker;
+
     @Bean
     public ProducerFactory<String, ChatMessageDto> producerFactory(){
         return new DefaultKafkaProducerFactory<>(kafkaProducerConfiguration());
@@ -27,7 +31,7 @@ public class KafkaProducerConfig {
     @Bean
     public Map<String, Object> kafkaProducerConfiguration() {
         final Map<String, Object> config = new HashMap<>();
-        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaConstants.KAFKA_BROKER);
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBroker);
         config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
         return config;


### PR DESCRIPTION
## Overview

- Config : 카프카 브로커 아이피 로컬호스트가 아닌 카프카 서버 아이피로 재설정

## Change Log

-

## To Reviewer

-

## Issue Tags

- #
