### PR TITLE
Feat: 카테고리, 신상품, 베스트, 이벤트 페이지네이션 구현

### DIFF
--- a/src/main/java/techit/gongsimchae/domain/groupbuying/category/service/CategoryService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/category/service/CategoryService.java
@@ -45,7 +45,7 @@ public class CategoryService {
         Event event = eventRepository.findById(eventId).orElseThrow(
                 () -> new CustomWebException(ErrorMessage.EVENT_NOT_FOUND)
         );
-        List<EventCategory> eventCategories = eventCategoryRepository.findAllByEventId(eventId);
+        List<EventCategory> eventCategories = eventCategoryRepository.findAllByEvent(event);
         for (EventCategory eventCategory : eventCategories) {
             Category category = eventCategory.getCategory();
             List<Item> items = itemRepository.findAllByCategory(category);

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/event/service/EventService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/event/service/EventService.java
@@ -105,4 +105,10 @@ public class EventService {
 
 
     }
+
+    public Event getEvent(Long eventId) {
+        return eventRepository.findById(eventId).orElseThrow(
+                () -> new CustomWebException(ErrorMessage.EVENT_NOT_FOUND)
+        );
+    }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/eventcategory/repository/EventCategoryRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/eventcategory/repository/EventCategoryRepository.java
@@ -2,10 +2,12 @@ package techit.gongsimchae.domain.groupbuying.eventcategory.repository;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import techit.gongsimchae.domain.groupbuying.event.entity.Event;
 import techit.gongsimchae.domain.groupbuying.eventcategory.entity.EventCategory;
 
 public interface EventCategoryRepository extends JpaRepository<EventCategory, Long> {
     void deleteAllByEventId(Long eventId);
+    List<EventCategory> findAllByEvent(Event event);
 
     List<EventCategory> findAllByEventId(Long eventId);
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/eventcategory/service/EventCategoryService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/eventcategory/service/EventCategoryService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import techit.gongsimchae.domain.groupbuying.category.entity.Category;
 import techit.gongsimchae.domain.groupbuying.category.repository.CategoryRepository;
+import techit.gongsimchae.domain.groupbuying.event.entity.Event;
 import techit.gongsimchae.domain.groupbuying.eventcategory.entity.EventCategory;
 import techit.gongsimchae.domain.groupbuying.eventcategory.repository.EventCategoryRepository;
 import techit.gongsimchae.global.exception.CustomWebException;
@@ -23,8 +24,8 @@ public class EventCategoryService {
         eventCategories.forEach(EventCategory::setStatusDeleted);
     }
 
-    public List<Category> getCategoriesByEvent(Long eventId) {
-        List<EventCategory> eventCategories = eventCategoryRepository.findAllByEventId(eventId);
+    public List<Category> getCategoriesByEvent(Event event) {
+        List<EventCategory> eventCategories = eventCategoryRepository.findAllByEvent(event);
         return eventCategories.stream()
                 .map((eventCategory -> categoryRepository.findById(eventCategory.getCategory().getId()).orElseThrow(
                         () -> new CustomWebException(ErrorMessage.CATEGORY_NOT_FOUND)

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/repository/ItemRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/repository/ItemRepository.java
@@ -17,8 +17,16 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemCustomRep
     List<Item> findAllByCategoryIn(List<Category> categories);
     Page<Item> findAllByCategory(Category category, Pageable pageable);
     Optional<Item> findByUID(String id);
+
+    /**
+     * 신상품 - 신상품순
+     */
+    @Query(
+            value = "SELECT * FROM (SELECT * FROM item ORDER BY create_date DESC LIMIT 200) sub",
+            countQuery = "SELECT COUNT(*) FROM (SELECT * FROM item ORDER BY create_date DESC LIMIT 200) sub",
+            nativeQuery = true
+    )
     Page<Item> findTop200ByOrderByCreateDateDesc(Pageable pageable);
-    Page<Item> findTop200ByOrderByCumulativeSalesVolumeDesc(Pageable pageable);
 
     /**
      * 신상품 - 판매량순
@@ -71,7 +79,17 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemCustomRep
     Page<Item> findTop200ByCumulativeSalesVolumeAndSortByCreateDateDesc(Pageable pageable);
 
     /**
-     * 신상품 - 리뷰많은순
+     * 베스트 - 판매량순
+     */
+    @Query(
+            value = "SELECT * FROM (SELECT * FROM item ORDER BY cumulative_sales_volume DESC LIMIT 200) sub",
+            countQuery = "SELECT COUNT(*) FROM (SELECT * FROM item ORDER BY cumulative_sales_volume DESC LIMIT 200) sub",
+            nativeQuery = true
+    )
+    Page<Item> findTop200ByOrderByCumulativeSalesVolumeDesc(Pageable pageable);
+
+    /**
+     * 베스트 - 리뷰많은순
      */
     @Query(
             value = "SELECT * FROM (SELECT * FROM item ORDER BY cumulative_sales_volume DESC LIMIT 200) sub ORDER BY review_count DESC",
@@ -81,7 +99,7 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemCustomRep
     Page<Item> findTop200ByCumulativeSalesVolumeAndSortByReviewCountDesc(Pageable pageable);
 
     /**
-     * 신상품 - 낮은가격순
+     * 베스트 - 낮은가격순
      */
     @Query(
             value = "SELECT * FROM (SELECT * FROM item ORDER BY cumulative_sales_volume DESC LIMIT 200) sub ORDER BY original_price ASC",
@@ -91,7 +109,7 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemCustomRep
     Page<Item> findTop200ByCumulativeSalesVolumeAndSortByOriginalPriceAsc(Pageable pageable);
 
     /**
-     * 신상품 - 높은 가격순
+     * 베스트 - 높은 가격순
      */
     @Query(
             value = "SELECT * FROM (SELECT * FROM item ORDER BY cumulative_sales_volume DESC LIMIT 200) sub ORDER BY original_price DESC",
@@ -99,4 +117,30 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemCustomRep
             nativeQuery = true
     )
     Page<Item> findTop200ByCumulativeSalesVolumeAndSortByOriginalPriceDesc(Pageable pageable);
+
+    // ------------------------------------------ 이벤트 아이템 ------------------------------------------------
+    /**
+     * 이벤트 - 신상품순
+     */
+    Page<Item> findAllByCategoryInOrderByCreateDateDesc(List<Category> categories, Pageable pageable);
+
+    /**
+     * 이벤트 - 판매량순
+     */
+    Page<Item> findAllByCategoryInOrderByCumulativeSalesVolumeDesc(List<Category> categories, Pageable pageable);
+
+    /**
+     * 이벤트 - 리뷰많은순
+     */
+    Page<Item> findAllByCategoryInOrderByReviewCount(List<Category> categories, Pageable pageable);
+
+    /**
+     * 이벤트 - 낮은가격순
+     */
+    Page<Item> findAllByCategoryInOrderByOriginalPriceAsc(List<Category> categories, Pageable pageable);
+
+    /**
+     * 이벤트 - 높은 가격순
+     */
+    Page<Item> findAllByCategoryInOrderByOriginalPriceDesc(List<Category> categories, Pageable pageable);
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemService.java
@@ -146,8 +146,11 @@ public class ItemService {
         return itemRepository.findAllByCategory(category);
     }
 
+    /**
+     * 카테고리 선택 페이지 반환
+     */
     @Transactional(readOnly = true)
-    public List<ItemCardResDtoWeb> getItemsPageByCategory(Category category, Integer page, Integer per_page,
+    public Page<ItemCardResDtoWeb> getItemsPageByCategory(Category category, Integer page, Integer per_page,
                                                           Integer sorted_type){
         SortType sortType = getInstanceByTypeNumber(sorted_type);
         Pageable pageable;
@@ -162,15 +165,13 @@ public class ItemService {
         } else if (sortType.equals(높은가격순)) {
             pageable = PageRequest.of(page, per_page, Sort.by(Direction.DESC, "originalPrice"));
         } else {
-            throw new CustomWebException("존재하지 않는 정렬기준입니다.");
+            throw new CustomWebException(ErrorMessage.SORT_TYPE_NOR_FOUND);
         }
         Page<Item> items = itemRepository.findAllByCategory(category, pageable);
-        List<ItemCardResDtoWeb> itemCardResDtoWebs = new ArrayList<>();
-        for (Item item : items) {
+        return items.map(item -> {
             ImageFile imageFile = imageFileRepository.findByItem(item);
-            itemCardResDtoWebs.add(new ItemCardResDtoWeb(item, imageFile));
-        }
-        return itemCardResDtoWebs;
+            return new ItemCardResDtoWeb(item, imageFile);
+        });
     }
 
     public ItemRespDtoWeb getItem(String id) {
@@ -181,7 +182,7 @@ public class ItemService {
     }
 
     @Transactional(readOnly = true)
-    public List<ItemCardResDtoWeb> getTop200NewItemsPage(Integer page, Integer per_page, Integer sorted_type) {
+    public Page<ItemCardResDtoWeb> getTop200NewItemsPage(Integer page, Integer per_page, Integer sorted_type) {
         SortType sortType = getInstanceByTypeNumber(sorted_type);
         Pageable pageable = PageRequest.of(page, per_page);
         Page<Item> newItemsPage;
@@ -196,18 +197,16 @@ public class ItemService {
         } else if (sortType.equals(높은가격순)) {
             newItemsPage = itemRepository.findTop200ByCreateDateAndSortByOriginalPriceDesc(pageable);
         } else {
-            throw new CustomWebException("존재하지 않는 정렬기준입니다.");
+            throw new CustomWebException(ErrorMessage.SORT_TYPE_NOR_FOUND);
         }
-        List<ItemCardResDtoWeb> itemCardResDtoWebs = new ArrayList<>();
-        for (Item item : newItemsPage) {
+        return newItemsPage.map(item -> {
             ImageFile imageFile = imageFileRepository.findByItem(item);
-            itemCardResDtoWebs.add(new ItemCardResDtoWeb(item, imageFile));
-        }
-        return itemCardResDtoWebs;
+            return new ItemCardResDtoWeb(item, imageFile);
+        });
     }
 
     @Transactional(readOnly = true)
-    public List<ItemCardResDtoWeb> getTop200BestItemsPage(Integer page, Integer per_page, Integer sorted_type) {
+    public Page<ItemCardResDtoWeb> getTop200BestItemsPage(Integer page, Integer per_page, Integer sorted_type) {
         SortType sortType = getInstanceByTypeNumber(sorted_type);
         Pageable pageable = PageRequest.of(page, per_page);
         Page<Item> bestItemsPage;
@@ -222,14 +221,35 @@ public class ItemService {
         } else if (sortType.equals(높은가격순)) {
             bestItemsPage = itemRepository.findTop200ByCumulativeSalesVolumeAndSortByOriginalPriceDesc(pageable);
         } else {
-            throw new CustomWebException("존재하지 않는 정렬기준입니다.");
+            throw new CustomWebException(ErrorMessage.SORT_TYPE_NOR_FOUND);
         }
-        List<ItemCardResDtoWeb> itemCardResDtoWebs = new ArrayList<>();
-        for (Item item : bestItemsPage) {
+        return bestItemsPage.map(item -> {
             ImageFile imageFile = imageFileRepository.findByItem(item);
-            itemCardResDtoWebs.add(new ItemCardResDtoWeb(item, imageFile));
+            return new ItemCardResDtoWeb(item, imageFile);
+        });
+    }
+
+    public Page<ItemCardResDtoWeb> getCategoriesItems(List<Category> categories, Integer page, Integer per_page, Integer sorted_type) {
+        SortType sortType = getInstanceByTypeNumber(sorted_type);
+        Pageable pageable = PageRequest.of(page, per_page);
+        Page<Item> categoriesItemsPage;
+        if (sortType.equals(신상품순)){
+            categoriesItemsPage = itemRepository.findAllByCategoryInOrderByCreateDateDesc(categories, pageable);
+        } else if (sortType.equals(판매량순)) {
+            categoriesItemsPage = itemRepository.findAllByCategoryInOrderByCumulativeSalesVolumeDesc(categories, pageable);
+        } else if (sortType.equals(리뷰많은순)){
+            categoriesItemsPage = itemRepository.findAllByCategoryInOrderByReviewCount(categories, pageable);
+        } else if (sortType.equals(낮은가격순)){
+            categoriesItemsPage = itemRepository.findAllByCategoryInOrderByOriginalPriceAsc(categories, pageable);
+        } else if (sortType.equals(높은가격순)) {
+            categoriesItemsPage = itemRepository.findAllByCategoryInOrderByOriginalPriceDesc(categories, pageable);
+        } else {
+            throw new CustomWebException(ErrorMessage.SORT_TYPE_NOR_FOUND);
         }
-        return itemCardResDtoWebs;
+        return categoriesItemsPage.map(item -> {
+            ImageFile imageFile = imageFileRepository.findByItem(item);
+            return new ItemCardResDtoWeb(item, imageFile);
+        });
     }
 
     public Page<ItemRespDtoWeb> searchItems(ItemSearchForm itemSearchForm, Pageable pageable) {
@@ -261,15 +281,5 @@ public class ItemService {
             }
         }
         return new ReviewItemResDtoWeb(reviewAbleItemResDtoWebs, reviewedItemResDtoWebs);
-    }
-
-    public List<ItemCardResDtoWeb> getCategoriesItems(List<Category> categories, Integer page, Integer perPage, Integer sortedType) {
-        List<Item> items = itemRepository.findAllByCategoryIn(categories);
-        List<ItemCardResDtoWeb> itemCardResDtoWebs = new ArrayList<>();
-        for (Item item : items) {
-            ImageFile imageFile = imageFileRepository.findByItem(item);
-            itemCardResDtoWebs.add(new ItemCardResDtoWeb(item, imageFile));
-        }
-        return itemCardResDtoWebs;
     }
 }

--- a/src/main/java/techit/gongsimchae/global/message/ErrorMessage.java
+++ b/src/main/java/techit/gongsimchae/global/message/ErrorMessage.java
@@ -13,17 +13,26 @@ public interface ErrorMessage {
     // 주소
     String ADDRESS_NOT_FOUND = "존재하지 않는 주소입니다.";
 
+    // 정렬
+    String SORT_TYPE_NOR_FOUND = "존재하지 않는 정렬기준입니다.";
+
     /**
      * groupBuying 에러
      */
 
+    // 이벤트
     String EVENT_TYPE_NOT_VALID = "유효하지 않은 이벤트 타입입니다.";
-    String CATEGORY_NAME_NOT_VALID = "유효하지 않은 카테고리 이름입니다.";
     String EVENT_BANNER_IMAGE_EMPTY = "이벤트 배너 이미지가 존재하지 않습니다.";
     String EVENT_NOT_FOUND = "이벤트가 존재하지 않습니다.";
+
+    // 아이템
     String ITEM_NOT_FOUND = "아이템이 존재하지 않습니다.";
     String ITEM_OPTION_NOT_FOUND = "유효하지 않은 상품 옵션입니다.";
+
+    // 카테고리
     String CATEGORY_NOT_FOUND = "존재하지 않는 카테고리입니다.";
+
+    // 쿠폰
     String COUPON_NOT_FOUND = "존재하지 않는 쿠폰입니다.";
     String COUPON_USER_ALREADY_EXIST = "이미 쿠폰을 발급받은 유저입니다.";
 
@@ -35,7 +44,6 @@ public interface ErrorMessage {
 
     // 채팅방
     String CHATTING_ROOM_NOT_FOUND = "존재하지 않는 채팅방입니다.";
-
 
     /**
      * global 에러

--- a/src/main/java/techit/gongsimchae/web/ItemController.java
+++ b/src/main/java/techit/gongsimchae/web/ItemController.java
@@ -10,6 +10,8 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import techit.gongsimchae.domain.groupbuying.category.entity.Category;
 import techit.gongsimchae.domain.groupbuying.category.service.CategoryService;
+import techit.gongsimchae.domain.groupbuying.event.entity.Event;
+import techit.gongsimchae.domain.groupbuying.event.service.EventService;
 import techit.gongsimchae.domain.groupbuying.eventcategory.service.EventCategoryService;
 import techit.gongsimchae.domain.groupbuying.item.dto.*;
 import techit.gongsimchae.domain.groupbuying.item.entity.Item;
@@ -29,6 +31,7 @@ public class ItemController {
     private final CategoryService categoryService;
     private final ItemOptionService itemOptionService;
     private final EventCategoryService eventCategoryService;
+    private final EventService eventService;
 
     /**
      * 검색
@@ -108,10 +111,10 @@ public class ItemController {
     @GetMapping("/category/{category_id}")
     public String getSelectedCategoryItems(@PathVariable Long category_id,
                                            @RequestParam(defaultValue = "1") Integer page,
-                                           @RequestParam(defaultValue = "96") Integer per_page,
+                                           @RequestParam(defaultValue = "48") Integer per_page,
                                            @RequestParam(defaultValue = "1") Integer sorted_type, Model model){
         Category category = categoryService.getCategoryById(category_id);
-        List<ItemCardResDtoWeb> itemsPage = itemService.getItemsPageByCategory(category, page - 1,
+        Page<ItemCardResDtoWeb> itemsPage = itemService.getItemsPageByCategory(category, page - 1,
                 per_page, sorted_type);
         model.addAttribute("categoryId", category_id);
         model.addAttribute("categoryName", category.getName());
@@ -126,9 +129,9 @@ public class ItemController {
      */
     @GetMapping("/collection-groups/new-item")
     public String getNewItems(@RequestParam(defaultValue = "1") Integer page,
-                              @RequestParam(defaultValue = "96") Integer per_page,
+                              @RequestParam(defaultValue = "48") Integer per_page,
                               @RequestParam(defaultValue = "1") Integer sorted_type, Model model){
-        List<ItemCardResDtoWeb> newItemsPage = itemService.getTop200NewItemsPage(page - 1, per_page, sorted_type);
+        Page<ItemCardResDtoWeb> newItemsPage = itemService.getTop200NewItemsPage(page - 1, per_page, sorted_type);
         model.addAttribute("newItemsPage", newItemsPage);
         return "category/newItem";
     }
@@ -141,9 +144,9 @@ public class ItemController {
 
     @GetMapping("/collection-groups/best-item")
     public String getBestItems(@RequestParam(defaultValue = "1") Integer page,
-                              @RequestParam(defaultValue = "96") Integer per_page,
+                              @RequestParam(defaultValue = "48") Integer per_page,
                               @RequestParam(defaultValue = "1") Integer sorted_type, Model model){
-        List<ItemCardResDtoWeb> bestItemsPage = itemService.getTop200BestItemsPage(page - 1, per_page, sorted_type);
+        Page<ItemCardResDtoWeb> bestItemsPage = itemService.getTop200BestItemsPage(page - 1, per_page, sorted_type);
         model.addAttribute("bestItemsPage", bestItemsPage);
         return "category/bestItem";
     }
@@ -156,11 +159,13 @@ public class ItemController {
     @GetMapping("/collection-groups/event-item")
     public String getEventItems(@RequestParam Long eventId,
                                 @RequestParam(defaultValue = "1") Integer page,
-                                @RequestParam(defaultValue = "96") Integer per_page,
+                                @RequestParam(defaultValue = "48") Integer per_page,
                                 @RequestParam(defaultValue = "1") Integer sorted_type, Model model){
-        List<Category> categories = eventCategoryService.getCategoriesByEvent(eventId);
-        List<ItemCardResDtoWeb> eventItems = itemService.getCategoriesItems(categories, page - 1, per_page, sorted_type);
-        model.addAttribute("eventCategories", categories);
+        Event event = eventService.getEvent(eventId);
+        List<Category> categories = eventCategoryService.getCategoriesByEvent(event);
+        Page<ItemCardResDtoWeb> eventItems = itemService.getCategoriesItems(categories, page - 1, per_page, sorted_type);
+        model.addAttribute("eventId", eventId);
+        model.addAttribute("eventName", event.getEventName());
         model.addAttribute("eventItems", eventItems);
         return "category/eventItem";
     }

--- a/src/main/resources/templates/category/bestItem.html
+++ b/src/main/resources/templates/category/bestItem.html
@@ -15,13 +15,13 @@
     <h1 class="category-alert">베스트</h1>
     <div class="item-grid-view-main">
         <div class="header">
-            <div class="category-alert-cnt" th:text="'총 ' + ${bestItemsPage.size()} + '건'"></div>
+            <div class="category-alert-cnt" th:text="'총 ' + ${bestItemsPage.totalElements} + '건'"></div>
             <ul class="category-sort-standard-ul">
-                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/best-item(page=1, per_page=96, sorted_type=1)}" class="category-sort-standard-alink">신상품순<p class="perpendicular-divider">|</p></a></li>
-                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/best-item(page=1, per_page=96, sorted_type=2)}"  class="category-sort-standard-alink">판매량순<p class="perpendicular-divider">|</p></a></li>
-                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/best-item(page=1, per_page=96, sorted_type=3)}"  class="category-sort-standard-alink">리뷰 많은 순<p class="perpendicular-divider">|</p></a></li>
-                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/best-item(page=1, per_page=96, sorted_type=4)}"  class="category-sort-standard-alink">낮은 가격순<p class="perpendicular-divider">|</p></a></li>
-                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/best-item(page=1, per_page=96, sorted_type=5)}"  class="category-sort-standard-alink">높은 가격순</a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/best-item(page=1, per_page=48, sorted_type=1)}" class="category-sort-standard-alink">신상품순<p class="perpendicular-divider">|</p></a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/best-item(page=1, per_page=48, sorted_type=2)}"  class="category-sort-standard-alink">판매량순<p class="perpendicular-divider">|</p></a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/best-item(page=1, per_page=48, sorted_type=3)}"  class="category-sort-standard-alink">리뷰 많은 순<p class="perpendicular-divider">|</p></a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/best-item(page=1, per_page=48, sorted_type=4)}"  class="category-sort-standard-alink">낮은 가격순<p class="perpendicular-divider">|</p></a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/best-item(page=1, per_page=48, sorted_type=5)}"  class="category-sort-standard-alink">높은 가격순</a></li>
             </ul>
         </div>
     </div>
@@ -58,6 +58,26 @@
                 </div>
             </div>
         </div>
+    </div>
+    <!-- 페이징 처리 -->
+    <div th:if="${!bestItemsPage.isEmpty()}" class="d-flex justify-content-center bg-white py-3">
+        <ul class="pagination mb-0">
+            <li class="page-item" th:classappend="${bestItemsPage.number == 0} ? 'disabled' : ''">
+                <a class="page-link" th:href="@{|?page=${bestItemsPage.number-1}|}" aria-label="Previous">
+                    <span aria-hidden="true">&laquo;</span>
+                </a>
+            </li>
+            <li th:each="page : ${#numbers.sequence(0, bestItemsPage.totalPages-1)}"
+                th:if="${page >= bestItemsPage.number-5 and page <= bestItemsPage.number+5}"
+                th:classappend="${page == bestItemsPage.number} ? 'active' : ''" class="page-item">
+                <a th:text="${page+1}" class="page-link" th:href="@{|?page=${page+1}|}"></a>
+            </li>
+            <li class="page-item" th:classappend="${bestItemsPage.number == bestItemsPage.totalPages-1} ? 'disabled' : ''">
+                <a class="page-link" th:href="@{|?page=${bestItemsPage.number+1}|}" aria-label="Next">
+                    <span aria-hidden="true">&raquo;</span>
+                </a>
+            </li>
+        </ul>
     </div>
 </section>
 </body>

--- a/src/main/resources/templates/category/category.html
+++ b/src/main/resources/templates/category/category.html
@@ -15,13 +15,13 @@
     <h1 class="category-alert" th:text="${categoryName}"></h1>
     <div class="item-grid-view-main">
         <div class="header">
-            <div class="category-alert-cnt" th:text="'총 ' + ${itemsPage.size()} + '건'"></div>
+            <div class="category-alert-cnt" th:text="'총 ' + ${itemsPage.totalElements} + '건'"></div>
             <ul class="category-sort-standard-ul">
-                <li class="category-sort-standard-li"><a th:href="@{/category/{category_id}(category_id=${categoryId}, page=1, per_page=96, sorted_type=1)}" class="category-sort-standard-alink">신상품순<p class="perpendicular-divider">|</p></a></li>
-                <li class="category-sort-standard-li"><a th:href="@{/category/{category_id}(category_id=${categoryId}, page=1, per_page=96, sorted_type=2)}"  class="category-sort-standard-alink">판매량순<p class="perpendicular-divider">|</p></a></li>
-                <li class="category-sort-standard-li"><a th:href="@{/category/{category_id}(category_id=${categoryId}, page=1, per_page=96, sorted_type=3)}"  class="category-sort-standard-alink">리뷰 많은 순<p class="perpendicular-divider">|</p></a></li>
-                <li class="category-sort-standard-li"><a th:href="@{/category/{category_id}(category_id=${categoryId}, page=1, per_page=96, sorted_type=4)}"  class="category-sort-standard-alink">낮은 가격순<p class="perpendicular-divider">|</p></a></li>
-                <li class="category-sort-standard-li"><a th:href="@{/category/{category_id}(category_id=${categoryId}, page=1, per_page=96, sorted_type=5)}"  class="category-sort-standard-alink">높은 가격순</a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/category/{category_id}(category_id=${categoryId}, page=1, per_page=48, sorted_type=1)}" class="category-sort-standard-alink">신상품순<p class="perpendicular-divider">|</p></a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/category/{category_id}(category_id=${categoryId}, page=1, per_page=48, sorted_type=2)}"  class="category-sort-standard-alink">판매량순<p class="perpendicular-divider">|</p></a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/category/{category_id}(category_id=${categoryId}, page=1, per_page=48, sorted_type=3)}"  class="category-sort-standard-alink">리뷰 많은 순<p class="perpendicular-divider">|</p></a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/category/{category_id}(category_id=${categoryId}, page=1, per_page=48, sorted_type=4)}"  class="category-sort-standard-alink">낮은 가격순<p class="perpendicular-divider">|</p></a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/category/{category_id}(category_id=${categoryId}, page=1, per_page=48, sorted_type=5)}"  class="category-sort-standard-alink">높은 가격순</a></li>
             </ul>
         </div>
     </div>
@@ -58,6 +58,26 @@
                 </div>
             </div>
         </div>
+    </div>
+    <!-- 페이징 처리 -->
+    <div th:if="${!itemsPage.isEmpty()}" class="d-flex justify-content-center bg-white py-3">
+        <ul class="pagination mb-0">
+            <li class="page-item" th:classappend="${itemsPage.number == 0} ? 'disabled' : ''">
+                <a class="page-link" th:href="@{|?page=${itemsPage.number-1}|}" aria-label="Previous">
+                    <span aria-hidden="true">&laquo;</span>
+                </a>
+            </li>
+            <li th:each="page : ${#numbers.sequence(0, itemsPage.totalPages-1)}"
+                th:if="${page >= itemsPage.number-5 and page <= itemsPage.number+5}"
+                th:classappend="${page == itemsPage.number} ? 'active' : ''" class="page-item">
+                <a th:text="${page+1}" class="page-link" th:href="@{|?page=${page+1}|}"></a>
+            </li>
+            <li class="page-item" th:classappend="${itemsPage.number == itemsPage.totalPages-1} ? 'disabled' : ''">
+                <a class="page-link" th:href="@{|?page=${itemsPage.number+1}|}" aria-label="Next">
+                    <span aria-hidden="true">&raquo;</span>
+                </a>
+            </li>
+        </ul>
     </div>
 </section>
 </body>

--- a/src/main/resources/templates/category/eventItem.html
+++ b/src/main/resources/templates/category/eventItem.html
@@ -14,18 +14,16 @@
 <body>
 <div th:replace="~{layout/navbar :: product_navbar}"></div>
 <section>
-  <h1 class="category-alert" th:each="eventCategory : ${eventCategories}">
-    <p th:text="${eventCategory.name}"></p>
-  </h1>
+  <h1 class="category-alert" th:text="${eventName}"></h1>
   <div class="item-grid-view-main">
     <div class="header">
-      <div class="category-alert-cnt" th:text="'총 ' + ${eventItems.size()} + '건'"></div>
+      <div class="category-alert-cnt" th:text="'총 ' + ${eventItems.totalElements} + '건'"></div>
       <ul class="category-sort-standard-ul">
-        <li class="category-sort-standard-li"><a th:href="@{/collection-groups/event-item(page=1, per_page=96, sorted_type=1)}" class="category-sort-standard-alink">신상품순<p class="perpendicular-divider">|</p></a></li>
-        <li class="category-sort-standard-li"><a th:href="@{/collection-groups/event-item(page=1, per_page=96, sorted_type=2)}"  class="category-sort-standard-alink">판매량순<p class="perpendicular-divider">|</p></a></li>
-        <li class="category-sort-standard-li"><a th:href="@{/collection-groups/event-item(page=1, per_page=96, sorted_type=3)}"  class="category-sort-standard-alink">리뷰 많은 순<p class="perpendicular-divider">|</p></a></li>
-        <li class="category-sort-standard-li"><a th:href="@{/collection-groups/event-item(page=1, per_page=96, sorted_type=4)}"  class="category-sort-standard-alink">낮은 가격순<p class="perpendicular-divider">|</p></a></li>
-        <li class="category-sort-standard-li"><a th:href="@{/collection-groups/event-item(page=1, per_page=96, sorted_type=5)}"  class="category-sort-standard-alink">높은 가격순</a></li>
+        <li class="category-sort-standard-li"><a th:href="@{/collection-groups/event-item(eventId = ${eventId}, page=1, per_page=48, sorted_type=1)}" class="category-sort-standard-alink">신상품순<p class="perpendicular-divider">|</p></a></li>
+        <li class="category-sort-standard-li"><a th:href="@{/collection-groups/event-item(eventId = ${eventId}, page=1, per_page=48, sorted_type=2)}"  class="category-sort-standard-alink">판매량순<p class="perpendicular-divider">|</p></a></li>
+        <li class="category-sort-standard-li"><a th:href="@{/collection-groups/event-item(eventId = ${eventId}, page=1, per_page=48, sorted_type=3)}"  class="category-sort-standard-alink">리뷰 많은 순<p class="perpendicular-divider">|</p></a></li>
+        <li class="category-sort-standard-li"><a th:href="@{/collection-groups/event-item(eventId = ${eventId}, page=1, per_page=48, sorted_type=4)}"  class="category-sort-standard-alink">낮은 가격순<p class="perpendicular-divider">|</p></a></li>
+        <li class="category-sort-standard-li"><a th:href="@{/collection-groups/event-item(eventId = ${eventId}, page=1, per_page=48, sorted_type=5)}"  class="category-sort-standard-alink">높은 가격순</a></li>
       </ul>
     </div>
   </div>
@@ -61,6 +59,26 @@
         </div>
       </div>
     </div>
+  </div>
+  <!-- 페이징 처리 -->
+  <div th:if="${!eventItems.isEmpty()}" class="d-flex justify-content-center bg-white py-3">
+    <ul class="pagination mb-0">
+      <li class="page-item" th:classappend="${eventItems.number == 0} ? 'disabled' : ''">
+        <a class="page-link" th:href="@{|?page=${eventItems.number-1}|}" aria-label="Previous">
+          <span aria-hidden="true">&laquo;</span>
+        </a>
+      </li>
+      <li th:each="page : ${#numbers.sequence(0, eventItems.totalPages-1)}"
+          th:if="${page >= eventItems.number-5 and page <= eventItems.number+5}"
+          th:classappend="${page == eventItems.number} ? 'active' : ''" class="page-item">
+        <a th:text="${page+1}" class="page-link" th:href="@{|?page=${page+1}|}"></a>
+      </li>
+      <li class="page-item" th:classappend="${eventItems.number == eventItems.totalPages-1} ? 'disabled' : ''">
+        <a class="page-link" th:href="@{|?page=${eventItems.number+1}|}" aria-label="Next">
+          <span aria-hidden="true">&raquo;</span>
+        </a>
+      </li>
+    </ul>
   </div>
 </section>
 </body>

--- a/src/main/resources/templates/category/newItem.html
+++ b/src/main/resources/templates/category/newItem.html
@@ -15,13 +15,13 @@
     <h1 class="category-alert">신상품</h1>
     <div class="item-grid-view-main">
         <div class="header">
-            <div class="category-alert-cnt" th:text="'총 ' + ${newItemsPage.size()} + '건'"></div>
+            <div class="category-alert-cnt" th:text="'총 ' + ${newItemsPage.totalElements} + '건'"></div>
             <ul class="category-sort-standard-ul">
-                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/new-item(page=1, per_page=96, sorted_type=1)}" class="category-sort-standard-alink">신상품순<p class="perpendicular-divider">|</p></a></li>
-                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/new-item(page=1, per_page=96, sorted_type=2)}"  class="category-sort-standard-alink">판매량순<p class="perpendicular-divider">|</p></a></li>
-                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/new-item(page=1, per_page=96, sorted_type=3)}"  class="category-sort-standard-alink">리뷰 많은 순<p class="perpendicular-divider">|</p></a></li>
-                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/new-item(page=1, per_page=96, sorted_type=4)}"  class="category-sort-standard-alink">낮은 가격순<p class="perpendicular-divider">|</p></a></li>
-                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/new-item(page=1, per_page=96, sorted_type=5)}"  class="category-sort-standard-alink">높은 가격순</a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/new-item(page=1, per_page=48, sorted_type=1)}" class="category-sort-standard-alink">신상품순<p class="perpendicular-divider">|</p></a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/new-item(page=1, per_page=48, sorted_type=2)}"  class="category-sort-standard-alink">판매량순<p class="perpendicular-divider">|</p></a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/new-item(page=1, per_page=48, sorted_type=3)}"  class="category-sort-standard-alink">리뷰 많은 순<p class="perpendicular-divider">|</p></a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/new-item(page=1, per_page=48, sorted_type=4)}"  class="category-sort-standard-alink">낮은 가격순<p class="perpendicular-divider">|</p></a></li>
+                <li class="category-sort-standard-li"><a th:href="@{/collection-groups/new-item(page=1, per_page=48, sorted_type=5)}"  class="category-sort-standard-alink">높은 가격순</a></li>
             </ul>
         </div>
     </div>
@@ -58,6 +58,26 @@
                 </div>
             </div>
         </div>
+    </div>
+    <!-- 페이징 처리 -->
+    <div th:if="${!newItemsPage.isEmpty()}" class="d-flex justify-content-center bg-white py-3">
+        <ul class="pagination mb-0">
+            <li class="page-item" th:classappend="${newItemsPage.number == 0} ? 'disabled' : ''">
+                <a class="page-link" th:href="@{|?page=${newItemsPage.number-1}|}" aria-label="Previous">
+                    <span aria-hidden="true">&laquo;</span>
+                </a>
+            </li>
+            <li th:each="page : ${#numbers.sequence(0, newItemsPage.totalPages-1)}"
+                th:if="${page >= newItemsPage.number-5 and page <= newItemsPage.number+5}"
+                th:classappend="${page == newItemsPage.number} ? 'active' : ''" class="page-item">
+                <a th:text="${page+1}" class="page-link" th:href="@{|?page=${page+1}|}"></a>
+            </li>
+            <li class="page-item" th:classappend="${newItemsPage.number == newItemsPage.totalPages-1} ? 'disabled' : ''">
+                <a class="page-link" th:href="@{|?page=${newItemsPage.number+1}|}" aria-label="Next">
+                    <span aria-hidden="true">&raquo;</span>
+                </a>
+            </li>
+        </ul>
     </div>
 </section>
 </body>

--- a/src/main/resources/templates/layout/navbar.html
+++ b/src/main/resources/templates/layout/navbar.html
@@ -77,7 +77,7 @@
                 <ul class="dropdown-menu">
                     <li th:each="category : ${categories}">
                         <a class="dropdown-item" th:text="${category.name}"
-                           th:href="@{/category/{category_id}(category_id=${category.id}, page=1, per_page=96, sorted_type=1)}"></a>
+                           th:href="@{/category/{category_id}(category_id=${category.id}, page=1, per_page=48, sorted_type=1)}"></a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
## Overview

- 아이템이 보이는 화면은 모두 페이지네이션 구현했습니다.

## Change Log

- 카테고리, 신상품, 베스트, 이벤트 페이지의 페이지네이션
- 이벤트의 경우 '할인' 이벤트 배너 클릭 시 해당 이벤트 카테고리의 상품이 페이지네이션되어 노출됩니다.
- 기존에 페이지당 96개의 아이템이 너무 많은 것 같아 48개로 줄였습니다.

## To Reviewer

-

## Issue Tags

- #
