### PR TITLE
Feat: 공동구매 성공 로직 구현 완료

### DIFF
--- a/src/main/java/techit/gongsimchae/domain/common/user/repository/UserCustomRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/common/user/repository/UserCustomRepository.java
@@ -3,6 +3,7 @@ package techit.gongsimchae.domain.common.user.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import techit.gongsimchae.domain.common.user.dto.UserRespDtoWeb;
+import techit.gongsimchae.domain.common.user.entity.User;
 import techit.gongsimchae.domain.portion.notifications.dto.NotificationKeywordUserDto;
 
 import java.util.List;
@@ -10,4 +11,6 @@ import java.util.List;
 public interface UserCustomRepository {
     List<NotificationKeywordUserDto> findUsersByKeyword(String address, String keyword);
     Page<UserRespDtoWeb> findUsersWithReportCounts(Pageable pageable);
+
+    List<User> findUsersByItemIdWithOrderItem(Long itemId);
 }

--- a/src/main/java/techit/gongsimchae/domain/common/user/repository/UserCustomRepositoryImpl.java
+++ b/src/main/java/techit/gongsimchae/domain/common/user/repository/UserCustomRepositoryImpl.java
@@ -9,6 +9,8 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import techit.gongsimchae.domain.common.address.entity.DefaultAddressStatus;
 import techit.gongsimchae.domain.common.user.dto.UserRespDtoWeb;
+import techit.gongsimchae.domain.common.user.entity.User;
+import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItemStatus;
 import techit.gongsimchae.domain.portion.notifications.dto.NotificationKeywordUserDto;
 import techit.gongsimchae.domain.portion.report.entity.QReport;
 import techit.gongsimchae.domain.portion.subdivision.entity.QSubdivision;
@@ -18,7 +20,11 @@ import java.util.List;
 
 import static techit.gongsimchae.domain.common.address.entity.QAddress.address1;
 import static techit.gongsimchae.domain.common.user.entity.QUser.user;
+import static techit.gongsimchae.domain.groupbuying.item.entity.QItem.item;
+import static techit.gongsimchae.domain.groupbuying.itemoption.entity.QItemOption.itemOption;
+import static techit.gongsimchae.domain.groupbuying.orderitem.entity.QOrderItem.orderItem;
 import static techit.gongsimchae.domain.portion.notificationkeyword.entity.QNotificationKeyword.notificationKeyword;
+import static techit.gongsimchae.domain.groupbuying.orders.entity.QOrders.orders;
 import static techit.gongsimchae.domain.portion.report.entity.QReport.*;
 import static techit.gongsimchae.domain.portion.subdivision.entity.QSubdivision.*;
 
@@ -70,5 +76,19 @@ public class UserCustomRepositoryImpl implements UserCustomRepository{
                 .fetchOne();
 
         return new PageImpl<>(results, pageable, size);
+    }
+
+    @Override
+    public List<User> findUsersByItemIdWithOrderItem(Long itemId) {
+        List<User> result = queryFactory.selectDistinct(Projections.constructor(User.class,
+                user)).from(user)
+                .join(user, orders.user)
+                .join(orders.orderItems, orderItem)
+                .join(orderItem.itemOption, itemOption)
+                .join(itemOption.item, item)
+                .where(item.id.eq(itemId).and(orderItem.orderItemStatus.eq(OrderItemStatus.결제완료)))
+                .fetch();
+
+        return result;
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/common/user/repository/UserCustomRepositoryImpl.java
+++ b/src/main/java/techit/gongsimchae/domain/common/user/repository/UserCustomRepositoryImpl.java
@@ -80,13 +80,14 @@ public class UserCustomRepositoryImpl implements UserCustomRepository{
 
     @Override
     public List<User> findUsersByItemIdWithOrderItem(Long itemId) {
-        List<User> result = queryFactory.selectDistinct(Projections.constructor(User.class,
-                user)).from(user)
-                .join(user, orders.user)
+        List<User> result = queryFactory.selectDistinct(Projections.fields(User.class,
+                        user.id, user.name, user.password, user.loginId, user.role, user.email, user.nickname, user.phoneNumber,
+                        user.mannerPoint, user.userStatus, user.UID, user.joinType)).from(orders)
+                .join(orders.user, user)
                 .join(orders.orderItems, orderItem)
                 .join(orderItem.itemOption, itemOption)
                 .join(itemOption.item, item)
-                .where(item.id.eq(itemId).and(orderItem.orderItemStatus.eq(OrderItemStatus.결제완료)))
+                .where(item.id.eq(itemId).and(orderItem.orderItemStatus.eq(OrderItemStatus.공동구매성공)))
                 .fetch();
 
         return result;

--- a/src/main/java/techit/gongsimchae/domain/common/user/service/UserService.java
+++ b/src/main/java/techit/gongsimchae/domain/common/user/service/UserService.java
@@ -215,4 +215,13 @@ public class UserService {
         user.ban();
     }
 
+    /**
+     * 공동구매 성공/실패 후 해당 아이템 아이디를 통해서 아이템을 주문한 유저들의 리스트를 반환합니다.
+     *
+     * @param itemId
+     * @return
+     */
+    public List<User> findUsersByItemId(Long itemId) {
+        return userRepository.findUsersByItemIdWithOrderItem(itemId);
+    }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/delivery/entity/Delivery.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/delivery/entity/Delivery.java
@@ -4,12 +4,13 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import techit.gongsimchae.domain.BaseEntity;
 import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItem;
 
 @Entity
 @Getter
 @NoArgsConstructor
-public class Delivery {
+public class Delivery extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,5 +27,9 @@ public class Delivery {
     public Delivery(DeliveryStatus deliveryStatus, OrderItem orderItem) {
         this.deliveryStatus = deliveryStatus;
         this.orderItem = orderItem;
+    }
+
+    public void updateDeliveryStatus(DeliveryStatus deliveryStatus) {
+        this.deliveryStatus = deliveryStatus;
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/delivery/entity/Delivery.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/delivery/entity/Delivery.java
@@ -1,6 +1,7 @@
 package techit.gongsimchae.domain.groupbuying.delivery.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItem;
@@ -20,4 +21,10 @@ public class Delivery {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_item_id")
     private OrderItem orderItem;
+
+    @Builder
+    public Delivery(DeliveryStatus deliveryStatus, OrderItem orderItem) {
+        this.deliveryStatus = deliveryStatus;
+        this.orderItem = orderItem;
+    }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/delivery/entity/Delivery.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/delivery/entity/Delivery.java
@@ -1,13 +1,9 @@
 package techit.gongsimchae.domain.groupbuying.delivery.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItem;
 
 @Entity
 @Getter
@@ -20,4 +16,8 @@ public class Delivery {
 
     @Enumerated(EnumType.STRING)
     private DeliveryStatus deliveryStatus;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_item_id")
+    private OrderItem orderItem;
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/delivery/entity/DeliveryStatus.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/delivery/entity/DeliveryStatus.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public enum DeliveryStatus {
 
-    배달완료,배달중,배달시작전,취소
+    배달완료, 배달중, 배달준비중, 배달시작전, 배달취소
 
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/delivery/repository/DeliveryRepository.java
@@ -1,9 +1,14 @@
 package techit.gongsimchae.domain.groupbuying.delivery.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import techit.gongsimchae.domain.groupbuying.delivery.entity.Delivery;
+import techit.gongsimchae.domain.groupbuying.delivery.entity.DeliveryStatus;
 
 @Repository
 public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
+
+    Page<Delivery> findByDeliveryStatus(DeliveryStatus deliveryStatus, Pageable pageable);
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/delivery/repository/DeliveryRepository.java
@@ -1,4 +1,9 @@
 package techit.gongsimchae.domain.groupbuying.delivery.repository;
 
-public class DeliveryRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import techit.gongsimchae.domain.groupbuying.delivery.entity.Delivery;
+
+@Repository
+public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/delivery/service/DeliveryService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/delivery/service/DeliveryService.java
@@ -1,4 +1,9 @@
 package techit.gongsimchae.domain.groupbuying.delivery.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class DeliveryService {
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/delivery/service/DeliveryService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/delivery/service/DeliveryService.java
@@ -2,8 +2,28 @@ package techit.gongsimchae.domain.groupbuying.delivery.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import techit.gongsimchae.domain.groupbuying.delivery.entity.Delivery;
+import techit.gongsimchae.domain.groupbuying.delivery.entity.DeliveryStatus;
+import techit.gongsimchae.domain.groupbuying.delivery.repository.DeliveryRepository;
+import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItem;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class DeliveryService {
+
+    private final DeliveryRepository deliveryRepository;
+
+    @Transactional
+    public Long registerDelivery(OrderItem orderItem) {
+        Delivery delivery = Delivery.builder()
+                .deliveryStatus(DeliveryStatus.배달준비중)
+                .orderItem(orderItem)
+                .build();
+
+        Long id = deliveryRepository.save(delivery).getId();
+
+        return id;
+    }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/entity/Item.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/entity/Item.java
@@ -77,4 +77,8 @@ public class Item extends BaseEntity {
     public void minusDiscountRate(Integer discountRate) {
         this.discountRate -= discountRate;
     }
+
+    public void updateItemStatus(ItemStatus itemStatus) {
+        this.itemStatus = itemStatus;
+    }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/entity/Item.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/entity/Item.java
@@ -41,6 +41,9 @@ public class Item extends BaseEntity {
     @OneToMany(mappedBy = "item")
     private List<ImageFile> imageFiles = new ArrayList<>();
 
+    @Enumerated(EnumType.STRING)
+    private ItemStatus itemStatus;
+
     public Item (ItemCreateDto itemCreateDto, Category category) {
         this.name = itemCreateDto.getName();
         this.intro = itemCreateDto.getIntro();
@@ -53,6 +56,7 @@ public class Item extends BaseEntity {
         this.UID = UUID.randomUUID().toString().substring(0,8);
         this.cumulativeSalesVolume = 0L;
         this.reviewCount = 0L;
+        this.itemStatus = ItemStatus.공동구매_진행중;
     }
 
     public void UpdateDto (ItemUpdateDto itemUpdateDto, Category category) {

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/entity/ItemStatus.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/entity/ItemStatus.java
@@ -1,0 +1,11 @@
+package techit.gongsimchae.domain.groupbuying.item.entity;
+
+import lombok.Getter;
+
+/**
+ * 공동 구매 현황에 대해 나타내는 상태 enum 값 입니다.
+ */
+@Getter
+public enum ItemStatus {
+    공동구매_준비중, 공동구매_진행중, 공동구매_마감
+}

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemService.java
@@ -32,12 +32,12 @@ import techit.gongsimchae.domain.groupbuying.item.dto.ReviewAbleItemResDtoWeb;
 import techit.gongsimchae.domain.groupbuying.item.dto.ReviewItemResDtoWeb;
 import techit.gongsimchae.domain.groupbuying.item.dto.ReviewedItemResDtoWeb;
 import techit.gongsimchae.domain.groupbuying.item.entity.Item;
+import techit.gongsimchae.domain.groupbuying.item.entity.ItemStatus;
 import techit.gongsimchae.domain.groupbuying.item.entity.SortType;
 import techit.gongsimchae.domain.groupbuying.item.repository.ItemRepository;
 import techit.gongsimchae.domain.groupbuying.itemoption.dto.ItemOptionCreateDto;
 import techit.gongsimchae.domain.groupbuying.itemoption.entity.ItemOption;
 import techit.gongsimchae.domain.groupbuying.itemoption.repository.ItemOptionRepository;
-import techit.gongsimchae.domain.groupbuying.itemoption.service.ItemOptionService;
 import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItem;
 import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderStatus;
 import techit.gongsimchae.domain.groupbuying.orderitem.repository.OrderItemRepository;
@@ -271,5 +271,16 @@ public class ItemService {
             itemCardResDtoWebs.add(new ItemCardResDtoWeb(item, imageFile));
         }
         return itemCardResDtoWebs;
+    }
+
+    /**
+     * 해당 아이템의 ItemStatus를 바꾸는 메서드 입니다.
+     *
+     * @param itemId
+     */
+    @Transactional
+    public void changeItemStatus(Long itemId, ItemStatus itemStatus) {
+        Item item = itemRepository.findById(itemId).orElseThrow(() -> new CustomWebException(ErrorMessage.ITEM_NOT_FOUND));
+        item.updateItemStatus(itemStatus);
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/itemoption/service/ItemOptionService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/itemoption/service/ItemOptionService.java
@@ -48,7 +48,7 @@ public class ItemOptionService {
                 .originalPrice(originalPrice)
                 .discountRate(item.getDiscountRate())
                 .discountPrice(discountPrice)
-                .quantity(1)
+                .quantity(item.getGroupBuyingQuantity())
                 .itemUID(item.getUID())
                 .build();
     }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/dto/CompletionAmountOrderItemCntDto.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/dto/CompletionAmountOrderItemCntDto.java
@@ -1,0 +1,15 @@
+package techit.gongsimchae.domain.groupbuying.orderitem.dto;
+
+import lombok.*;
+
+/**
+ * 결제까지 완료된 상태인 특정 아이템의 갯수를 담습니다.
+ */
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompletionAmountOrderItemCntDto {
+    private Integer completionAmountCnt;
+}

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/entity/OrderItem.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/entity/OrderItem.java
@@ -35,4 +35,8 @@ public class OrderItem extends BaseEntity {
         this.itemOption = itemOption;
         this.orderItemStatus = orderItemStatus;
     }
+
+    public void updateOrderItemStatus(OrderItemStatus orderItemStatus) {
+        this.orderItemStatus = orderItemStatus;
+    }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/entity/OrderItem.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/entity/OrderItem.java
@@ -24,12 +24,15 @@ public class OrderItem extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "itemOption_id")
     private ItemOption itemOption;
+    @Enumerated(EnumType.STRING)
+    private OrderItemStatus orderItemStatus;
 
     @Builder
-    public OrderItem(Integer price, Integer count, Orders orders, ItemOption itemOption) {
+    public OrderItem(Integer price, Integer count, Orders orders, ItemOption itemOption, OrderItemStatus orderItemStatus) {
         this.price = price;
         this.count = count;
         this.orders = orders;
         this.itemOption = itemOption;
+        this.orderItemStatus = orderItemStatus;
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/entity/OrderItemStatus.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/entity/OrderItemStatus.java
@@ -1,0 +1,8 @@
+package techit.gongsimchae.domain.groupbuying.orderitem.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum OrderItemStatus {
+    주문완료, 주문취소, 결제완료, 결제취소, 공동구매성공, 공동구매실패
+}

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/repository/OrderItemCustomRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/repository/OrderItemCustomRepository.java
@@ -1,8 +1,13 @@
 package techit.gongsimchae.domain.groupbuying.orderitem.repository;
 
 import techit.gongsimchae.domain.groupbuying.orderitem.dto.CompletionAmountOrderItemCntDto;
+import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItem;
+
+import java.util.List;
 
 public interface OrderItemCustomRepository {
 
     CompletionAmountOrderItemCntDto countCompletedOrderItemsByItemId(Long itemId);
+
+    List<OrderItem> findOrderItemsByItemId(Long itemId);
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/repository/OrderItemCustomRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/repository/OrderItemCustomRepository.java
@@ -1,0 +1,8 @@
+package techit.gongsimchae.domain.groupbuying.orderitem.repository;
+
+import techit.gongsimchae.domain.groupbuying.orderitem.dto.CompletionAmountOrderItemCntDto;
+
+public interface OrderItemCustomRepository {
+
+    CompletionAmountOrderItemCntDto countCompletedOrderItemsByItemId(Long itemId);
+}

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/repository/OrderItemCustomRepositoryImpl.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/repository/OrderItemCustomRepositoryImpl.java
@@ -4,7 +4,10 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import techit.gongsimchae.domain.groupbuying.orderitem.dto.CompletionAmountOrderItemCntDto;
+import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItem;
 import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItemStatus;
+
+import java.util.List;
 
 import static techit.gongsimchae.domain.groupbuying.item.entity.QItem.item;
 import static techit.gongsimchae.domain.groupbuying.itemoption.entity.QItemOption.itemOption;
@@ -18,9 +21,22 @@ public class OrderItemCustomRepositoryImpl implements OrderItemCustomRepository 
     public CompletionAmountOrderItemCntDto countCompletedOrderItemsByItemId(Long itemId) {
         CompletionAmountOrderItemCntDto result = queryFactory.select(Projections.constructor(CompletionAmountOrderItemCntDto.class,
                 orderItem.count.sum())).from(orderItem)
+                .join(orderItem.itemOption, itemOption)
                 .join(itemOption.item, item)
                 .where(item.id.eq(itemId).and(orderItem.orderItemStatus.eq(OrderItemStatus.결제완료)))
                 .fetchOne();
+
+        return result;
+    }
+
+    @Override
+    public List<OrderItem> findOrderItemsByItemId(Long itemId) {
+        List<OrderItem> result = queryFactory.select(Projections.constructor(OrderItem.class,
+                orderItem)).from(orderItem)
+                .join(orderItem.itemOption, itemOption)
+                .join(itemOption.item, item)
+                .where(item.id.eq(itemId).and(orderItem.orderItemStatus.eq(OrderItemStatus.결제완료)))
+                .fetch();
 
         return result;
     }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/repository/OrderItemCustomRepositoryImpl.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/repository/OrderItemCustomRepositoryImpl.java
@@ -31,8 +31,9 @@ public class OrderItemCustomRepositoryImpl implements OrderItemCustomRepository 
 
     @Override
     public List<OrderItem> findOrderItemsByItemId(Long itemId) {
-        List<OrderItem> result = queryFactory.select(Projections.constructor(OrderItem.class,
-                orderItem)).from(orderItem)
+        List<OrderItem> result = queryFactory.select(Projections.fields(OrderItem.class,
+                        orderItem.id, orderItem.price, orderItem.count, orderItem.orders, orderItem.itemOption, orderItem.orderItemStatus))
+                .from(orderItem)
                 .join(orderItem.itemOption, itemOption)
                 .join(itemOption.item, item)
                 .where(item.id.eq(itemId).and(orderItem.orderItemStatus.eq(OrderItemStatus.결제완료)))

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/repository/OrderItemCustomRepositoryImpl.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/repository/OrderItemCustomRepositoryImpl.java
@@ -20,7 +20,7 @@ public class OrderItemCustomRepositoryImpl implements OrderItemCustomRepository 
     @Override
     public CompletionAmountOrderItemCntDto countCompletedOrderItemsByItemId(Long itemId) {
         CompletionAmountOrderItemCntDto result = queryFactory.select(Projections.constructor(CompletionAmountOrderItemCntDto.class,
-                orderItem.count.sum())).from(orderItem)
+                orderItem.count.sum().coalesce(0))).from(orderItem)
                 .join(orderItem.itemOption, itemOption)
                 .join(itemOption.item, item)
                 .where(item.id.eq(itemId).and(orderItem.orderItemStatus.eq(OrderItemStatus.결제완료)))

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/repository/OrderItemCustomRepositoryImpl.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/repository/OrderItemCustomRepositoryImpl.java
@@ -1,0 +1,27 @@
+package techit.gongsimchae.domain.groupbuying.orderitem.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import techit.gongsimchae.domain.groupbuying.orderitem.dto.CompletionAmountOrderItemCntDto;
+import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItemStatus;
+
+import static techit.gongsimchae.domain.groupbuying.item.entity.QItem.item;
+import static techit.gongsimchae.domain.groupbuying.itemoption.entity.QItemOption.itemOption;
+import static techit.gongsimchae.domain.groupbuying.orderitem.entity.QOrderItem.orderItem;
+
+@RequiredArgsConstructor
+public class OrderItemCustomRepositoryImpl implements OrderItemCustomRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public CompletionAmountOrderItemCntDto countCompletedOrderItemsByItemId(Long itemId) {
+        CompletionAmountOrderItemCntDto result = queryFactory.select(Projections.constructor(CompletionAmountOrderItemCntDto.class,
+                orderItem.count.sum())).from(orderItem)
+                .join(itemOption.item, item)
+                .where(item.id.eq(itemId).and(orderItem.orderItemStatus.eq(OrderItemStatus.결제완료)))
+                .fetchOne();
+
+        return result;
+    }
+}

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/repository/OrderItemRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/repository/OrderItemRepository.java
@@ -6,7 +6,7 @@ import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItem;
 import java.util.List;
 import techit.gongsimchae.domain.groupbuying.orders.entity.Orders;
 
-public interface OrderItemRepository extends JpaRepository<OrderItem,Long> {
+public interface OrderItemRepository extends JpaRepository<OrderItem,Long>, OrderItemCustomRepository {
     List<OrderItem> findByOrdersId(Long id);
 
     List<OrderItem> findAllByOrdersIn(List<Orders> orders);

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/service/OrderItemService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/service/OrderItemService.java
@@ -3,7 +3,11 @@ package techit.gongsimchae.domain.groupbuying.orderitem.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import techit.gongsimchae.domain.groupbuying.orderitem.dto.CompletionAmountOrderItemCntDto;
+import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItem;
+import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItemStatus;
 import techit.gongsimchae.domain.groupbuying.orderitem.repository.OrderItemRepository;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -11,7 +15,28 @@ public class OrderItemService {
 
     private final OrderItemRepository orderItemRepository;
 
+    /**
+     * 해당 아이템을 주문해서 결제 완료한 수량이 몇 인지 카운트하는 메서드입니다.
+     *
+     * @param itemId
+     * @return
+     */
     public CompletionAmountOrderItemCntDto getCountCompletedOrderItemsWithItemId(Long itemId) {
         return orderItemRepository.countCompletedOrderItemsByItemId(itemId);
+    }
+
+    /**
+     * 공동구매가 성공되었을 때 이벤트 리스너로 실행되는 메서드입니다.
+     * 해당 itemId로 결제까지 완료한 OrderItem들을 찾아 그 상태 값을 파라미터로 넘겨받은 orderItemStatus로 바꿔주는 메서드입니다.
+     *
+     * @param itemId
+     * @param orderItemStatus
+     */
+    public void changeOrderItemStatusWithItemId(Long itemId, OrderItemStatus orderItemStatus) {
+        List<OrderItem> orderItems = orderItemRepository.findOrderItemsByItemId(itemId);
+
+        for (OrderItem orderItem : orderItems) {
+            orderItem.updateOrderItemStatus(orderItemStatus);
+        }
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/service/OrderItemService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/service/OrderItemService.java
@@ -39,4 +39,14 @@ public class OrderItemService {
             orderItem.updateOrderItemStatus(orderItemStatus);
         }
     }
+
+    /**
+     * 해당 itemId로 orderItem들을 찾아 반환하는 메서드입니다.
+     *
+     * @param itemId
+     * @return
+     */
+    public List<OrderItem> getOrderItemsByItemId(Long itemId) {
+        return orderItemRepository.findOrderItemsByItemId(itemId);
+    }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/service/OrderItemService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/service/OrderItemService.java
@@ -2,6 +2,7 @@ package techit.gongsimchae.domain.groupbuying.orderitem.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import techit.gongsimchae.domain.groupbuying.orderitem.dto.CompletionAmountOrderItemCntDto;
 import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItem;
 import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItemStatus;
@@ -11,6 +12,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OrderItemService {
 
     private final OrderItemRepository orderItemRepository;
@@ -32,11 +34,13 @@ public class OrderItemService {
      * @param itemId
      * @param orderItemStatus
      */
+    @Transactional
     public void changeOrderItemStatusWithItemId(Long itemId, OrderItemStatus orderItemStatus) {
         List<OrderItem> orderItems = orderItemRepository.findOrderItemsByItemId(itemId);
 
         for (OrderItem orderItem : orderItems) {
             orderItem.updateOrderItemStatus(orderItemStatus);
+            orderItemRepository.save(orderItem);
         }
     }
 

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/service/OrderItemService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/service/OrderItemService.java
@@ -1,4 +1,17 @@
 package techit.gongsimchae.domain.groupbuying.orderitem.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import techit.gongsimchae.domain.groupbuying.orderitem.dto.CompletionAmountOrderItemCntDto;
+import techit.gongsimchae.domain.groupbuying.orderitem.repository.OrderItemRepository;
+
+@Service
+@RequiredArgsConstructor
 public class OrderItemService {
+
+    private final OrderItemRepository orderItemRepository;
+
+    public CompletionAmountOrderItemCntDto getCountCompletedOrderItemsWithItemId(Long itemId) {
+        return orderItemRepository.countCompletedOrderItemsByItemId(itemId);
+    }
 }

--- a/src/main/java/techit/gongsimchae/domain/portion/notifications/entity/NotificationType.java
+++ b/src/main/java/techit/gongsimchae/domain/portion/notifications/entity/NotificationType.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum NotificationType {
-    INQUIRY("문의"), KEYWORD("알림 키워드"), CHAT("채팅"), FEEDBACK("피드백");
+    INQUIRY("문의"), KEYWORD("알림 키워드"), CHAT("채팅"), FEEDBACK("피드백"), GROUP_BUYING("공동구매");
     private String description;
 }

--- a/src/main/java/techit/gongsimchae/domain/portion/notifications/event/GroupBuyingNotiEvent.java
+++ b/src/main/java/techit/gongsimchae/domain/portion/notifications/event/GroupBuyingNotiEvent.java
@@ -1,0 +1,15 @@
+package techit.gongsimchae.domain.portion.notifications.event;
+
+import lombok.Data;
+import techit.gongsimchae.domain.common.user.entity.User;
+
+@Data
+public class GroupBuyingNotiEvent {
+    private User user;
+    private String content;
+
+    public GroupBuyingNotiEvent(User user, String content) {
+        this.user = user;
+        this.content = content;
+    }
+}

--- a/src/main/java/techit/gongsimchae/domain/portion/notifications/event/NotiEventHandler.java
+++ b/src/main/java/techit/gongsimchae/domain/portion/notifications/event/NotiEventHandler.java
@@ -46,4 +46,12 @@ public class NotiEventHandler {
         notificationService.alertAboutFeedback(event);
         log.debug("noti to inquiry {}", event);
     }
+
+    @TransactionalEventListener
+    @Async("customTaskExecutor")
+    public void SendGroupBuyingNotifications(GroupBuyingNotiEvent event) throws InterruptedException {
+        Thread.sleep(2000);
+        notificationService.alertAboutGroupBuying(event);
+        log.debug("noti to GroupBuying {}", event);
+    }
 }

--- a/src/main/java/techit/gongsimchae/domain/portion/notifications/event/NotiEventHandler.java
+++ b/src/main/java/techit/gongsimchae/domain/portion/notifications/event/NotiEventHandler.java
@@ -47,7 +47,7 @@ public class NotiEventHandler {
         log.debug("noti to inquiry {}", event);
     }
 
-    @TransactionalEventListener
+    @EventListener
     @Async("customTaskExecutor")
     public void SendGroupBuyingNotifications(GroupBuyingNotiEvent event) throws InterruptedException {
         Thread.sleep(2000);

--- a/src/main/java/techit/gongsimchae/domain/portion/notifications/service/NotificationService.java
+++ b/src/main/java/techit/gongsimchae/domain/portion/notifications/service/NotificationService.java
@@ -16,6 +16,7 @@ import techit.gongsimchae.domain.portion.notifications.entity.NotificationType;
 import techit.gongsimchae.domain.portion.notifications.entity.Notifications;
 import techit.gongsimchae.domain.portion.notifications.event.ChatNotiEvent;
 import techit.gongsimchae.domain.portion.notifications.event.FeedbackNotiEvent;
+import techit.gongsimchae.domain.portion.notifications.event.GroupBuyingNotiEvent;
 import techit.gongsimchae.domain.portion.notifications.event.KeywordNotiEvent;
 import techit.gongsimchae.domain.portion.notifications.repository.EmitterRepository;
 import techit.gongsimchae.domain.portion.notifications.repository.NotificationRepository;
@@ -169,5 +170,22 @@ public class NotificationService {
      */
     private User getCurrentUser(PrincipalDetails principalDetails) {
         return userRepository.findByLoginId(principalDetails.getUsername()).orElseThrow(() -> new RuntimeException("User not found"));
+    }
+
+    /**
+     * 공동구매 성공/실패 여부 알림 메서드
+     * @param event
+     */
+    @Transactional
+    public void alertAboutGroupBuying(GroupBuyingNotiEvent event) {
+        Notifications notifications = Notifications.builder()
+                .user(event.getUser())
+                .isRead(0)
+                .url("/mypage/orders")
+                .content(event.getContent())
+                .notificationType(NotificationType.GROUP_BUYING)
+                .build();
+
+        notificationRepository.save(notifications);
     }
 }

--- a/src/main/java/techit/gongsimchae/global/batch/delivery/DeliveryBatch.java
+++ b/src/main/java/techit/gongsimchae/global/batch/delivery/DeliveryBatch.java
@@ -1,0 +1,128 @@
+package techit.gongsimchae.global.batch.delivery;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.RepositoryItemWriter;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.batch.item.data.builder.RepositoryItemWriterBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.PlatformTransactionManager;
+import techit.gongsimchae.domain.groupbuying.delivery.entity.Delivery;
+import techit.gongsimchae.domain.groupbuying.delivery.entity.DeliveryStatus;
+import techit.gongsimchae.domain.groupbuying.delivery.repository.DeliveryRepository;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class DeliveryBatch {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final DeliveryRepository deliveryRepository;
+
+    @Bean
+    public Job updateDeliveryStatusJob() {
+        return new JobBuilder("updateDeliveryStatusJob", jobRepository)
+                .start(updateDeliveryStatusStep())
+                .build();
+    }
+
+    @Bean
+    public Step updateDeliveryStatusStep() {
+        return new StepBuilder("updateDeliveryStatusStep", jobRepository)
+                .<Delivery, Delivery>chunk(10, transactionManager)
+                .reader(deliveryReader())
+                .processor(deliveryProcessor())
+                .writer(deliveryWriter())
+                .build();
+    }
+
+    @Bean
+    public RepositoryItemReader<Delivery> deliveryReader() {
+        return new RepositoryItemReaderBuilder<Delivery>()
+                .name("deliveryReader")
+                .pageSize(10)
+                .methodName("findByDeliveryStatus")
+                .arguments(Collections.singletonList(DeliveryStatus.배달준비중))
+                .repository(deliveryRepository)
+                .sorts(Map.of("createDate", Sort.Direction.ASC))
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<Delivery, Delivery> deliveryProcessor() {
+        return (delivery -> {
+            ZonedDateTime tenMinutesAgo = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(10);
+
+            if (delivery.getCreateDate().isBefore(tenMinutesAgo.toLocalDateTime())) {
+                delivery.updateDeliveryStatus(DeliveryStatus.배달중);
+                return delivery;
+            } else {
+                return null;
+            }
+        });
+    }
+
+    @Bean
+    public RepositoryItemWriter<Delivery> deliveryWriter() {
+        return new RepositoryItemWriterBuilder<Delivery>()
+                .repository(deliveryRepository)
+                .methodName("save")
+                .build();
+    }
+
+    @Bean
+    public Job updateDeliveryStatusToCompleteJob() {
+        return new JobBuilder("updateDeliveryStatusToCompleteJob", jobRepository)
+                .start(updateDeliveryStatusCompleteStep())
+                .build();
+    }
+
+    @Bean
+    public Step updateDeliveryStatusCompleteStep() {
+        return new StepBuilder("updateDeliveryStatusCompleteStep", jobRepository)
+                .<Delivery, Delivery>chunk(10, transactionManager)
+                .reader(deliveryForCompleteReader())
+                .processor(deliveryForCompleteProcessor())
+                .writer(deliveryWriter())
+                .build();
+    }
+
+    @Bean
+    public RepositoryItemReader<Delivery> deliveryForCompleteReader() {
+        return new RepositoryItemReaderBuilder<Delivery>()
+                .name("deliveryForCompleteReader")
+                .pageSize(10)
+                .methodName("findByDeliveryStatus")
+                .arguments(Collections.singletonList(DeliveryStatus.배달중))
+                .repository(deliveryRepository)
+                .sorts(Map.of("createDate", Sort.Direction.ASC))
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<Delivery, Delivery> deliveryForCompleteProcessor() {
+        return (delivery -> {
+            ZonedDateTime tenMinutesAgo = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(20);
+
+            if (delivery.getUpdateDate().isBefore(tenMinutesAgo.toLocalDateTime())) {
+                delivery.updateDeliveryStatus(DeliveryStatus.배달완료);
+                return delivery;
+            } else {
+                return null;
+            }
+        });
+    }
+}

--- a/src/main/java/techit/gongsimchae/global/batch/delivery/DeliveryBatch.java
+++ b/src/main/java/techit/gongsimchae/global/batch/delivery/DeliveryBatch.java
@@ -79,7 +79,7 @@ public class DeliveryBatch {
     public RepositoryItemWriter<Delivery> deliveryWriter() {
         return new RepositoryItemWriterBuilder<Delivery>()
                 .repository(deliveryRepository)
-                .methodName("save")
+                .methodName("saveAll")
                 .build();
     }
 

--- a/src/main/java/techit/gongsimchae/global/batch/delivery/DeliverySchedule.java
+++ b/src/main/java/techit/gongsimchae/global/batch/delivery/DeliverySchedule.java
@@ -1,0 +1,47 @@
+package techit.gongsimchae.global.batch.delivery;
+
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.configuration.JobRegistry;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+@Configuration
+public class DeliverySchedule {
+
+    private final JobLauncher jobLauncher;
+    private final JobRegistry jobRegistry;
+
+    public DeliverySchedule(JobLauncher jobLauncher, JobRegistry jobRegistry) {
+        this.jobLauncher = jobLauncher;
+        this.jobRegistry = jobRegistry;
+    }
+
+    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
+    public void runDeliveryStatusJob() throws Exception {
+        System.out.println("first delivery schedule start");
+        String date = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("date", date)
+                .toJobParameters();
+
+        jobLauncher.run(jobRegistry.getJob("updateDeliveryStatusJob"), jobParameters);
+    }
+
+    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
+    public void runDeliveryStatusCompletionJob() throws Exception {
+        System.out.println("second delivery schedule start");
+        String date = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("date", date)
+                .toJobParameters();
+
+        jobLauncher.run(jobRegistry.getJob("updateDeliveryStatusToCompleteJob"), jobParameters);
+    }
+}

--- a/src/main/java/techit/gongsimchae/global/event/TargetCountAchievedEvent.java
+++ b/src/main/java/techit/gongsimchae/global/event/TargetCountAchievedEvent.java
@@ -1,7 +1,6 @@
 package techit.gongsimchae.global.event;
 
 import lombok.Getter;
-import techit.gongsimchae.domain.groupbuying.item.entity.Item;
 
 @Getter
 public class TargetCountAchievedEvent {

--- a/src/main/java/techit/gongsimchae/global/event/TargetCountAchievedEvent.java
+++ b/src/main/java/techit/gongsimchae/global/event/TargetCountAchievedEvent.java
@@ -1,0 +1,15 @@
+package techit.gongsimchae.global.event;
+
+import lombok.Getter;
+import techit.gongsimchae.domain.groupbuying.item.entity.Item;
+
+@Getter
+public class TargetCountAchievedEvent {
+
+    private Long itemId;
+
+    public TargetCountAchievedEvent(Long itemId) {
+        this.itemId = itemId;
+    }
+
+}

--- a/src/main/java/techit/gongsimchae/global/event/handler/GroupBuyingSuccessEventHandler.java
+++ b/src/main/java/techit/gongsimchae/global/event/handler/GroupBuyingSuccessEventHandler.java
@@ -1,14 +1,21 @@
 package techit.gongsimchae.global.event.handler;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import techit.gongsimchae.domain.common.user.entity.User;
+import techit.gongsimchae.domain.common.user.service.UserService;
 import techit.gongsimchae.domain.groupbuying.delivery.service.DeliveryService;
+import techit.gongsimchae.domain.groupbuying.item.entity.Item;
 import techit.gongsimchae.domain.groupbuying.item.entity.ItemStatus;
 import techit.gongsimchae.domain.groupbuying.item.service.ItemService;
 import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItemStatus;
 import techit.gongsimchae.domain.groupbuying.orderitem.service.OrderItemService;
+import techit.gongsimchae.domain.portion.notifications.event.GroupBuyingNotiEvent;
 import techit.gongsimchae.global.event.TargetCountAchievedEvent;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -17,6 +24,8 @@ public class GroupBuyingSuccessEventHandler {
     private final ItemService itemService;
     private final OrderItemService orderItemService;
     private final DeliveryService deliveryService;
+    private final ApplicationEventPublisher publisher;
+    private final UserService userService;
 
     @EventListener
     public void changeItemStatus(TargetCountAchievedEvent event) {
@@ -30,7 +39,12 @@ public class GroupBuyingSuccessEventHandler {
 
     @EventListener
     public void sendNotification(TargetCountAchievedEvent event) {
+        List<User> users = userService.findUsersByItemId(event.getItemId());
+        Item item = itemService.getItemById(event.getItemId());
 
+        for (User user : users) {
+            publisher.publishEvent(new GroupBuyingNotiEvent(user, item.getName() + "에 대한 공동구매가 성공했습니다! 배송 준비 중에 있으니 잠시만 기다려주세요."));
+        }
     }
 
     @EventListener

--- a/src/main/java/techit/gongsimchae/global/event/handler/GroupBuyingSuccessEventHandler.java
+++ b/src/main/java/techit/gongsimchae/global/event/handler/GroupBuyingSuccessEventHandler.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import techit.gongsimchae.domain.groupbuying.delivery.service.DeliveryService;
 import techit.gongsimchae.domain.groupbuying.item.entity.ItemStatus;
 import techit.gongsimchae.domain.groupbuying.item.service.ItemService;
+import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItemStatus;
 import techit.gongsimchae.domain.groupbuying.orderitem.service.OrderItemService;
 import techit.gongsimchae.global.event.TargetCountAchievedEvent;
 
@@ -24,7 +25,7 @@ public class GroupBuyingSuccessEventHandler {
 
     @EventListener
     public void changeOrderItemStatus(TargetCountAchievedEvent event) {
-
+        orderItemService.changeOrderItemStatusWithItemId(event.getItemId(), OrderItemStatus.공동구매성공);
     }
 
     @EventListener

--- a/src/main/java/techit/gongsimchae/global/event/handler/GroupBuyingSuccessEventHandler.java
+++ b/src/main/java/techit/gongsimchae/global/event/handler/GroupBuyingSuccessEventHandler.java
@@ -3,6 +3,7 @@ package techit.gongsimchae.global.event.handler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import techit.gongsimchae.domain.common.user.entity.User;
 import techit.gongsimchae.domain.common.user.service.UserService;
@@ -10,6 +11,7 @@ import techit.gongsimchae.domain.groupbuying.delivery.service.DeliveryService;
 import techit.gongsimchae.domain.groupbuying.item.entity.Item;
 import techit.gongsimchae.domain.groupbuying.item.entity.ItemStatus;
 import techit.gongsimchae.domain.groupbuying.item.service.ItemService;
+import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItem;
 import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItemStatus;
 import techit.gongsimchae.domain.groupbuying.orderitem.service.OrderItemService;
 import techit.gongsimchae.domain.portion.notifications.event.GroupBuyingNotiEvent;
@@ -27,16 +29,19 @@ public class GroupBuyingSuccessEventHandler {
     private final ApplicationEventPublisher publisher;
     private final UserService userService;
 
+    @Order(1)
     @EventListener
     public void changeItemStatus(TargetCountAchievedEvent event) {
         itemService.changeItemStatus(event.getItemId(), ItemStatus.공동구매_마감);
     }
 
+    @Order(2)
     @EventListener
     public void changeOrderItemStatus(TargetCountAchievedEvent event) {
         orderItemService.changeOrderItemStatusWithItemId(event.getItemId(), OrderItemStatus.공동구매성공);
     }
 
+    @Order(3)
     @EventListener
     public void sendNotification(TargetCountAchievedEvent event) {
         List<User> users = userService.findUsersByItemId(event.getItemId());
@@ -47,8 +52,13 @@ public class GroupBuyingSuccessEventHandler {
         }
     }
 
+    @Order(4)
     @EventListener
     public void createDelivery(TargetCountAchievedEvent event) {
+        List<OrderItem> orderItems = orderItemService.getOrderItemsByItemId(event.getItemId());
 
+        for (OrderItem orderItem : orderItems) {
+            deliveryService.registerDelivery(orderItem);
+        }
     }
 }

--- a/src/main/java/techit/gongsimchae/global/event/handler/GroupBuyingSuccessEventHandler.java
+++ b/src/main/java/techit/gongsimchae/global/event/handler/GroupBuyingSuccessEventHandler.java
@@ -1,25 +1,22 @@
 package techit.gongsimchae.global.event.handler;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import techit.gongsimchae.domain.common.user.entity.User;
-import techit.gongsimchae.domain.common.user.service.UserService;
 import techit.gongsimchae.domain.groupbuying.delivery.service.DeliveryService;
-import techit.gongsimchae.domain.groupbuying.item.entity.Item;
 import techit.gongsimchae.domain.groupbuying.item.entity.ItemStatus;
 import techit.gongsimchae.domain.groupbuying.item.service.ItemService;
 import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItem;
 import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItemStatus;
 import techit.gongsimchae.domain.groupbuying.orderitem.service.OrderItemService;
-import techit.gongsimchae.domain.portion.notifications.event.GroupBuyingNotiEvent;
 import techit.gongsimchae.global.event.TargetCountAchievedEvent;
 
 import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class GroupBuyingSuccessEventHandler {
@@ -27,8 +24,6 @@ public class GroupBuyingSuccessEventHandler {
     private final ItemService itemService;
     private final OrderItemService orderItemService;
     private final DeliveryService deliveryService;
-    private final ApplicationEventPublisher publisher;
-    private final UserService userService;
 
     @Async
     @Order(1)
@@ -44,7 +39,7 @@ public class GroupBuyingSuccessEventHandler {
         orderItemService.changeOrderItemStatusWithItemId(event.getItemId(), OrderItemStatus.공동구매성공);
     }
 
-    @Async
+    /*@Async
     @Order(3)
     @EventListener
     public void sendNotification(TargetCountAchievedEvent event) {
@@ -52,12 +47,21 @@ public class GroupBuyingSuccessEventHandler {
         Item item = itemService.getItemById(event.getItemId());
 
         for (User user : users) {
-            publisher.publishEvent(new GroupBuyingNotiEvent(user, item.getName() + "에 대한 공동구매가 성공했습니다! 배송 준비 중에 있으니 잠시만 기다려주세요."));
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronizationAdapter() {
+                        @Override
+                        public void afterCommit() {
+                            log.debug("group buying event");
+                            publisher.publishEvent(new GroupBuyingNotiEvent(user, item.getName() + "에 대한 공동구매가 성공했습니다! 배송 준비 중에 있으니 잠시만 기다려주세요."));
+
+                        }
+                    }
+            );
         }
-    }
+    }*/
 
     @Async
-    @Order(4)
+    @Order(3)
     @EventListener
     public void createDelivery(TargetCountAchievedEvent event) {
         List<OrderItem> orderItems = orderItemService.getOrderItemsByItemId(event.getItemId());

--- a/src/main/java/techit/gongsimchae/global/event/handler/GroupBuyingSuccessEventHandler.java
+++ b/src/main/java/techit/gongsimchae/global/event/handler/GroupBuyingSuccessEventHandler.java
@@ -1,0 +1,39 @@
+package techit.gongsimchae.global.event.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import techit.gongsimchae.domain.groupbuying.delivery.service.DeliveryService;
+import techit.gongsimchae.domain.groupbuying.item.entity.ItemStatus;
+import techit.gongsimchae.domain.groupbuying.item.service.ItemService;
+import techit.gongsimchae.domain.groupbuying.orderitem.service.OrderItemService;
+import techit.gongsimchae.global.event.TargetCountAchievedEvent;
+
+@Component
+@RequiredArgsConstructor
+public class GroupBuyingSuccessEventHandler {
+
+    private final ItemService itemService;
+    private final OrderItemService orderItemService;
+    private final DeliveryService deliveryService;
+
+    @EventListener
+    public void changeItemStatus(TargetCountAchievedEvent event) {
+        itemService.changeItemStatus(event.getItemId(), ItemStatus.공동구매_마감);
+    }
+
+    @EventListener
+    public void changeOrderItemStatus(TargetCountAchievedEvent event) {
+
+    }
+
+    @EventListener
+    public void sendNotification(TargetCountAchievedEvent event) {
+
+    }
+
+    @EventListener
+    public void createDelivery(TargetCountAchievedEvent event) {
+
+    }
+}

--- a/src/main/java/techit/gongsimchae/global/event/handler/GroupBuyingSuccessEventHandler.java
+++ b/src/main/java/techit/gongsimchae/global/event/handler/GroupBuyingSuccessEventHandler.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import techit.gongsimchae.domain.common.user.entity.User;
 import techit.gongsimchae.domain.common.user.service.UserService;
@@ -29,18 +30,21 @@ public class GroupBuyingSuccessEventHandler {
     private final ApplicationEventPublisher publisher;
     private final UserService userService;
 
+    @Async
     @Order(1)
     @EventListener
     public void changeItemStatus(TargetCountAchievedEvent event) {
         itemService.changeItemStatus(event.getItemId(), ItemStatus.공동구매_마감);
     }
 
+    @Async
     @Order(2)
     @EventListener
     public void changeOrderItemStatus(TargetCountAchievedEvent event) {
         orderItemService.changeOrderItemStatusWithItemId(event.getItemId(), OrderItemStatus.공동구매성공);
     }
 
+    @Async
     @Order(3)
     @EventListener
     public void sendNotification(TargetCountAchievedEvent event) {
@@ -52,6 +56,7 @@ public class GroupBuyingSuccessEventHandler {
         }
     }
 
+    @Async
     @Order(4)
     @EventListener
     public void createDelivery(TargetCountAchievedEvent event) {

--- a/src/main/java/techit/gongsimchae/global/event/handler/GroupBuyingSuccessEventHandler.java
+++ b/src/main/java/techit/gongsimchae/global/event/handler/GroupBuyingSuccessEventHandler.java
@@ -39,27 +39,6 @@ public class GroupBuyingSuccessEventHandler {
         orderItemService.changeOrderItemStatusWithItemId(event.getItemId(), OrderItemStatus.공동구매성공);
     }
 
-    /*@Async
-    @Order(3)
-    @EventListener
-    public void sendNotification(TargetCountAchievedEvent event) {
-        List<User> users = userService.findUsersByItemId(event.getItemId());
-        Item item = itemService.getItemById(event.getItemId());
-
-        for (User user : users) {
-            TransactionSynchronizationManager.registerSynchronization(
-                    new TransactionSynchronizationAdapter() {
-                        @Override
-                        public void afterCommit() {
-                            log.debug("group buying event");
-                            publisher.publishEvent(new GroupBuyingNotiEvent(user, item.getName() + "에 대한 공동구매가 성공했습니다! 배송 준비 중에 있으니 잠시만 기다려주세요."));
-
-                        }
-                    }
-            );
-        }
-    }*/
-
     @Async
     @Order(3)
     @EventListener

--- a/src/main/java/techit/gongsimchae/web/ItemController.java
+++ b/src/main/java/techit/gongsimchae/web/ItemController.java
@@ -16,6 +16,7 @@ import techit.gongsimchae.domain.groupbuying.item.entity.Item;
 import techit.gongsimchae.domain.groupbuying.item.service.ItemService;
 import techit.gongsimchae.domain.groupbuying.itemoption.dto.ItemOptionDto;
 import techit.gongsimchae.domain.groupbuying.itemoption.service.ItemOptionService;
+import techit.gongsimchae.domain.groupbuying.orderitem.service.OrderItemService;
 import techit.gongsimchae.global.dto.PrincipalDetails;
 
 import java.util.List;
@@ -29,6 +30,7 @@ public class ItemController {
     private final CategoryService categoryService;
     private final ItemOptionService itemOptionService;
     private final EventCategoryService eventCategoryService;
+    private final OrderItemService orderItemService;
 
     /**
      * 검색
@@ -94,7 +96,10 @@ public class ItemController {
     @GetMapping("/product/{id}")
     public String itemDetails(@PathVariable("id") Long id, Model model) {
         List<ItemOptionDto> item = itemOptionService.getItemOptionById(id);
+
         model.addAttribute("item",item);
+        model.addAttribute("completionAmountItemCntDto", orderItemService.getCountCompletedOrderItemsWithItemId(id));
+
         return "groupbuying/itemDetails";
     }
 

--- a/src/main/resources/templates/groupbuying/itemDetails.html
+++ b/src/main/resources/templates/groupbuying/itemDetails.html
@@ -47,9 +47,14 @@
 <div class="separator-detail"></div>
 <section class="status-detail-container">
     <div class="progress">
-        <div class="progress-bar bg-success" role="progressbar" style="width: 50%;" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></div>
+        <div class="progress-bar bg-success" role="progressbar"
+             th:style="'width:' + (${completionAmountItemCntDto.completionAmountCnt} / ${item[0].quantity} * 100) + '%;'"
+             aria-valuenow="[[${completionAmountItemCntDto.completionAmountCnt}]]"
+             aria-valuemin="0"
+             aria-valuemax="[[${item[0].quantity}]]">
+        </div>
     </div>
-    <span>목표 수량: 100 / 달성량: 50</span>
+    <span>목표 수량: <span th:text="${item[0].quantity}"></span> / 달성량: <span th:text="${completionAmountItemCntDto.completionAmountCnt}"></span></span>
 </section>
 <section class="product-description-detail">
     <h4>상품 설명</h4>


### PR DESCRIPTION
## Overview

- 공동구매 성공 시 실행되어야 하는 이벤트 리스너 작성하였습니다.
- 배송 상태값 변경은 배치 작업으로 진행합니다.
- 공동구매 로직 정리 페이지 입니다. https://www.notion.so/633ca2ceeeb54ec1a38bc79b91325aea?pvs=4

## Change Log

- 아이템마다 각각 다르게 공동구매를 진행하기 때문에 OrderItem도 OrderItemStatus를 가지도록 수정하였습니다.

## To Reviewer

-  공동구매 성공 후 배송 데이터가 바로 만들어지는 데 현재 테스트하기 위해서 10분, 20분 간격으로 DeliveryStatus가 바뀌게 설정하였습니다. 실 서버에서는 하루, 이틀 뒤에 바뀌도록 구성할 예정입니다.
- 공동구매 성공 후 아이템 관련 로직 처리는 아직 안되어 있습니다.

## Issue Tags

- #
