### PR TITLE
Feat: 결제취소 제외 공동구매 실패 로직 구현

### DIFF
--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/repository/ItemRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/repository/ItemRepository.java
@@ -6,7 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import techit.gongsimchae.domain.groupbuying.category.entity.Category;
 import techit.gongsimchae.domain.groupbuying.item.entity.Item;
+import techit.gongsimchae.domain.groupbuying.item.entity.ItemStatus;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -143,4 +145,9 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemCustomRep
      * 이벤트 - 높은 가격순
      */
     Page<Item> findAllByCategoryInOrderByOriginalPriceDesc(List<Category> categories, Pageable pageable);
+
+    /**
+     * 스케줄러 - 해당 ItemStatus를 가진 아이템 리스트 반환
+     */
+    List<Item> findAllByItemStatusAndGroupBuyingLimitTimeBefore(ItemStatus itemStatus, LocalDateTime groupBuyingLimitTime);
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemScheduler.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemScheduler.java
@@ -1,0 +1,56 @@
+package techit.gongsimchae.domain.groupbuying.item.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import techit.gongsimchae.domain.common.user.entity.User;
+import techit.gongsimchae.domain.groupbuying.item.entity.Item;
+import techit.gongsimchae.domain.groupbuying.item.entity.ItemStatus;
+import techit.gongsimchae.domain.groupbuying.item.repository.ItemRepository;
+import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItem;
+import techit.gongsimchae.domain.groupbuying.orderitem.service.OrderItemService;
+import techit.gongsimchae.domain.portion.notifications.event.GroupBuyingNotiEvent;
+import techit.gongsimchae.global.event.TargetCountAchievedFailEvent;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ItemScheduler {
+
+    private final ItemRepository itemRepository;
+    private final OrderItemService orderItemService;
+    private final ApplicationEventPublisher publisher;
+
+    @Scheduled(cron = "0 */1 * * * *", zone = "Asia/Seoul") // 10분 마다 실행
+    @Transactional
+    public void checkAndChangeItemStatus() {
+        LocalDateTime now = LocalDateTime.now();
+
+        List<Item> items = itemRepository.findAllByItemStatusAndGroupBuyingLimitTimeBefore(ItemStatus.공동구매_진행중, now);
+
+        for (Item item : items) {
+            int completionAmountCnt = orderItemService.getCountCompletedOrderItemsWithItemId(item.getId()).getCompletionAmountCnt();
+
+            // 주문 수량이 목표 수량보다 작을 때 공동 구매 실패 로직 처리
+            if (item.getGroupBuyingQuantity() > completionAmountCnt) {
+                publisher.publishEvent(new TargetCountAchievedFailEvent(item.getId()));
+
+                List<OrderItem> orderItems = orderItemService.getOrderItemsByItemId(item.getId());
+                List<User> users = orderItems.stream().map(orderItem -> orderItem.getOrders().getUser()).distinct().toList();
+
+                for (User user : users) {
+                    publisher.publishEvent(new GroupBuyingNotiEvent(user, item.getName() + " 상품에 대한 공동구매가 실패하였습니다. 곧 환불 조치를 취할 예정이니 잠시만 기다려주세요."));
+                }
+
+            }
+        }
+
+        itemRepository.saveAll(items);
+    }
+
+}

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemScheduler.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemScheduler.java
@@ -26,7 +26,7 @@ public class ItemScheduler {
     private final OrderItemService orderItemService;
     private final ApplicationEventPublisher publisher;
 
-    @Scheduled(cron = "0 */1 * * * *", zone = "Asia/Seoul") // 10분 마다 실행
+    @Scheduled(cron = "0 */10 * * * *", zone = "Asia/Seoul") // 10분 마다 실행
     @Transactional
     public void checkAndChangeItemStatus() {
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/service/OrderItemService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/orderitem/service/OrderItemService.java
@@ -28,7 +28,7 @@ public class OrderItemService {
     }
 
     /**
-     * 공동구매가 성공되었을 때 이벤트 리스너로 실행되는 메서드입니다.
+     * 공동구매가 성공/실패되었을 때 이벤트 리스너로 실행되는 메서드입니다.
      * 해당 itemId로 결제까지 완료한 OrderItem들을 찾아 그 상태 값을 파라미터로 넘겨받은 orderItemStatus로 바꿔주는 메서드입니다.
      *
      * @param itemId

--- a/src/main/java/techit/gongsimchae/global/event/TargetCountAchievedFailEvent.java
+++ b/src/main/java/techit/gongsimchae/global/event/TargetCountAchievedFailEvent.java
@@ -1,0 +1,13 @@
+package techit.gongsimchae.global.event;
+
+import lombok.Getter;
+
+@Getter
+public class TargetCountAchievedFailEvent {
+
+    private Long itemId;
+
+    public TargetCountAchievedFailEvent(Long itemId) {
+        this.itemId = itemId;
+    }
+}

--- a/src/main/java/techit/gongsimchae/global/event/handler/GroupBuyingFailEventHandler.java
+++ b/src/main/java/techit/gongsimchae/global/event/handler/GroupBuyingFailEventHandler.java
@@ -1,0 +1,41 @@
+package techit.gongsimchae.global.event.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import techit.gongsimchae.domain.groupbuying.item.entity.ItemStatus;
+import techit.gongsimchae.domain.groupbuying.item.service.ItemService;
+import techit.gongsimchae.domain.groupbuying.orderitem.entity.OrderItemStatus;
+import techit.gongsimchae.domain.groupbuying.orderitem.service.OrderItemService;
+import techit.gongsimchae.global.event.TargetCountAchievedFailEvent;
+
+@Component
+@RequiredArgsConstructor
+public class GroupBuyingFailEventHandler {
+
+    private final ItemService itemService;
+    private final OrderItemService orderItemService;
+
+    @Async
+    @Order(1)
+    @EventListener
+    public void changeItemStatus(TargetCountAchievedFailEvent event) {
+        itemService.changeItemStatus(event.getItemId(), ItemStatus.공동구매_마감);
+    }
+
+    @Async
+    @Order(2)
+    @EventListener
+    public void changeOrderItemStatus(TargetCountAchievedFailEvent event) {
+        orderItemService.changeOrderItemStatusWithItemId(event.getItemId(), OrderItemStatus.공동구매실패);
+    }
+
+    @Async
+    @Order(3)
+    @EventListener
+    public void refundMoney(TargetCountAchievedFailEvent event) {
+        // TODO 환불 로직 작성
+    }
+}


### PR DESCRIPTION
## Overview

- 공동구매가 실패했을 때 실행되는 로직을 구현하였습니다.
- 스케줄러를 사용해서 현재는 10분마다 아이템들의 마감시간을 체크하도록 구현하였습니다.

## Change Log

-

## To Reviewer

- 아이템 마감 시간을 1시간 단위로만 설정 할 수 있게 제한을 두어 10분이 아닌 1시간마다 원활하게 체크하는 것이 어떨까 합니다.

## Issue Tags

- #
