### PR TITLE
Feat: 공동구매 재진행 로직 구현 및 상품 상세 페이지 작성

### DIFF
--- a/src/main/java/techit/gongsimchae/domain/common/imagefile/entity/ImageFile.java
+++ b/src/main/java/techit/gongsimchae/domain/common/imagefile/entity/ImageFile.java
@@ -1,12 +1,6 @@
 package techit.gongsimchae.domain.common.imagefile.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,6 +28,9 @@ public class ImageFile extends BaseEntity {
     private String originalFilename;
     private String storeFilename;
     private Integer imageFileStatus;
+
+    @Enumerated(EnumType.STRING)
+    private ItemImageFileStatus itemImageFileStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -82,11 +79,12 @@ public class ImageFile extends BaseEntity {
         this.imageFileStatus = 0;
     }
 
-    public ImageFile(String originalFilename, String storeFilename, Item item) {
+    public ImageFile(String originalFilename, String storeFilename, Item item, ItemImageFileStatus itemImageFileStatus) {
         this.originalFilename = originalFilename;
         this.storeFilename = storeFilename;
         this.item = item;
         this.imageFileStatus = 0;
+        this.itemImageFileStatus = itemImageFileStatus;
     }
 
     public ImageFile(String originalFilename, String storeFilename, Subdivision subdivision) {

--- a/src/main/java/techit/gongsimchae/domain/common/imagefile/entity/ItemImageFileStatus.java
+++ b/src/main/java/techit/gongsimchae/domain/common/imagefile/entity/ItemImageFileStatus.java
@@ -1,0 +1,9 @@
+package techit.gongsimchae.domain.common.imagefile.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum ItemImageFileStatus {
+    THUMBNAIL,
+    DETAIL     // 상품 상세 설명 이미지
+}

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/cart/dto/CartItemDto.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/cart/dto/CartItemDto.java
@@ -2,6 +2,7 @@ package techit.gongsimchae.domain.groupbuying.cart.dto;
 
 import lombok.Builder;
 import lombok.Data;
+import techit.gongsimchae.domain.groupbuying.item.entity.ItemStatus;
 
 import java.time.LocalDateTime;
 
@@ -20,9 +21,10 @@ public class CartItemDto {
     private String options;
     private String content;
     private LocalDateTime groupBuyingLimitTime;
+    private ItemStatus itemStatus;
 
     @Builder
-    public CartItemDto(Long cartId, Long itemId, Long itemOptionId, String itemName, Integer originalPrice, Integer discountRate, Integer discountPrice, Integer groupBuyingQuantity, Integer quantity, Integer totalPrice, LocalDateTime groupBuyingLimitTime,String options,String content) {
+    public CartItemDto(Long cartId, Long itemId, Long itemOptionId, String itemName, Integer originalPrice, Integer discountRate, Integer discountPrice, Integer groupBuyingQuantity, Integer quantity, Integer totalPrice, LocalDateTime groupBuyingLimitTime,String options,String content, ItemStatus itemStatus) {
         this.cartId = cartId;
         this.itemId = itemId;
         this.itemOptionId = itemOptionId;
@@ -36,5 +38,6 @@ public class CartItemDto {
         this.options = options;
         this.content = content;
         this.groupBuyingLimitTime = groupBuyingLimitTime;
+        this.itemStatus = itemStatus;
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/cart/service/CartService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/cart/service/CartService.java
@@ -102,6 +102,7 @@ public class CartService {
                 .quantity(cart.getCount())
                 .totalPrice(totalPrice)
                 .groupBuyingLimitTime(item.getGroupBuyingLimitTime())
+                .itemStatus(item.getItemStatus())
                 .build();
     }
 

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/dto/ItemCardResDtoWeb.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/dto/ItemCardResDtoWeb.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import techit.gongsimchae.domain.common.imagefile.entity.ImageFile;
 import techit.gongsimchae.domain.groupbuying.item.entity.Item;
+import techit.gongsimchae.domain.groupbuying.item.entity.ItemStatus;
 
 @Data
 @NoArgsConstructor
@@ -23,6 +24,7 @@ public class ItemCardResDtoWeb {
     private Long cumulativeSalesVolume;
     private Long reviewCount;
     private String itemBannerImage;
+    private ItemStatus itemStatus;
 
     public ItemCardResDtoWeb(Item item, ImageFile imageFile){
         this.id = item.getId();
@@ -38,6 +40,7 @@ public class ItemCardResDtoWeb {
         this.reviewCount = item.getReviewCount();
         if(imageFile != null)
             this.itemBannerImage = imageFile.getStoreFilename();
+        this.itemStatus = item.getItemStatus();
     }
 
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/dto/ItemCreateDto.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/dto/ItemCreateDto.java
@@ -21,5 +21,6 @@ public class ItemCreateDto {
     private List<MultipartFile> images;
 
     private List<ItemOptionCreateDto> options = new ArrayList<>();
+    private List<MultipartFile> detailImages;
 
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/dto/ItemRespDtoWeb.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/dto/ItemRespDtoWeb.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import techit.gongsimchae.domain.groupbuying.item.entity.Item;
+import techit.gongsimchae.domain.groupbuying.item.entity.ItemStatus;
 
 @Data
 @NoArgsConstructor
@@ -27,6 +28,7 @@ public class ItemRespDtoWeb {
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
     private List<String> imageUrls = new ArrayList<>();
+    private ItemStatus itemStatus;
 
     public ItemRespDtoWeb(Item item) {
         this.id = item.getId();
@@ -45,6 +47,7 @@ public class ItemRespDtoWeb {
         this.updateDate = item.getUpdateDate();
         // todo 추후 이미지파일 넣어야됨
         this.imageUrls = null;
+        this.itemStatus = item.getItemStatus();
     }
 
     public ItemRespDtoWeb(Item item, List<String> imageUrls) {
@@ -63,5 +66,6 @@ public class ItemRespDtoWeb {
         this.createDate = item.getCreateDate();
         this.updateDate = item.getUpdateDate();
         this.imageUrls = imageUrls;
+        this.itemStatus = item.getItemStatus();
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/dto/ItemUpdateDto.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/dto/ItemUpdateDto.java
@@ -21,5 +21,5 @@ public class ItemUpdateDto {
     private List<MultipartFile> images;
     private List<Long> deleteImages;
     private List<ItemOptionUpdateDto> options = new ArrayList<>();
-
+    private List<MultipartFile> detailImages;
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/entity/Item.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/entity/Item.java
@@ -51,6 +51,9 @@ public class Item extends BaseEntity {
     @OneToMany(mappedBy = "item")
     private List<ItemOption> itemOptions = new ArrayList<>();
 
+    @OneToMany(mappedBy = "item")
+    private List<ImageFile> detailImageFiles = new ArrayList<>();
+
     public Item (ItemCreateDto itemCreateDto, Category category) {
         this.name = itemCreateDto.getName();
         this.intro = itemCreateDto.getIntro();

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/entity/Item.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/entity/Item.java
@@ -51,9 +51,6 @@ public class Item extends BaseEntity {
     @OneToMany(mappedBy = "item")
     private List<ItemOption> itemOptions = new ArrayList<>();
 
-    @OneToMany(mappedBy = "item")
-    private List<ImageFile> detailImageFiles = new ArrayList<>();
-
     public Item (ItemCreateDto itemCreateDto, Category category) {
         this.name = itemCreateDto.getName();
         this.intro = itemCreateDto.getIntro();

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemScheduler.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemScheduler.java
@@ -26,7 +26,7 @@ public class ItemScheduler {
     private final OrderItemService orderItemService;
     private final ApplicationEventPublisher publisher;
 
-    @Scheduled(cron = "0 */10 * * * *", zone = "Asia/Seoul") // 10분 마다 실행
+    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul") // 매 시 정각마다 실행
     @Transactional
     public void checkAndChangeItemStatus() {
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemService.java
@@ -79,7 +79,7 @@ public class ItemService {
         Item item = new Item(itemCreateDto, category);
         Item savedItem = itemRepository.save(item);
 
-        List<ImageFile> imageFiles = imageS3Service.storeFiles(itemCreateDto.getImages(), "images", item);
+        List<ImageFile> imageFiles = imageS3Service.storeFiles(itemCreateDto.getImages(), "images", item, ItemImageFileStatus.THUMBNAIL);
         List<ImageFile> detailImageFiles = imageS3Service.storeFiles(itemCreateDto.getDetailImages(), "images", item, ItemImageFileStatus.DETAIL);
 
         createItemDocument(savedItem, imageFiles);

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemService.java
@@ -105,7 +105,7 @@ public class ItemService {
     }
 
     @Transactional
-    public void updateItem(Long id, ItemUpdateDto itemUpdateDto) {
+    public Item updateItem(Long id, ItemUpdateDto itemUpdateDto) {
         Item item = itemRepository.findById(id).filter(i -> i.getDeleteStatus() == 0)
                 .orElseThrow(() -> new CustomWebException(ErrorMessage.ITEM_NOT_FOUND));
 
@@ -153,7 +153,7 @@ public class ItemService {
                 .filter(option -> !updatedOptionIds.contains(option.getId()))
                 .forEach(itemOptionRepository::delete);
 
-        itemRepository.save(item);
+        return itemRepository.save(item);
     }
 
     @Transactional

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/service/ItemService.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import techit.gongsimchae.domain.common.imagefile.entity.ImageFile;
+import techit.gongsimchae.domain.common.imagefile.entity.ItemImageFileStatus;
 import techit.gongsimchae.domain.common.imagefile.repository.ImageFileRepository;
 import techit.gongsimchae.domain.common.imagefile.service.ImageS3Service;
 import techit.gongsimchae.domain.groupbuying.category.entity.Category;
@@ -93,7 +94,9 @@ public class ItemService {
         Item item = new Item(itemCreateDto, category);
         itemRepository.save(item);
 
-        imageS3Service.storeFiles(itemCreateDto.getImages(), "images", item);
+        imageS3Service.storeFiles(itemCreateDto.getImages(), "images", item, ItemImageFileStatus.THUMBNAIL);
+        imageS3Service.storeFiles(itemCreateDto.getDetailImages(), "images", item, ItemImageFileStatus.DETAIL);
+
 
         if (itemCreateDto.getOptions() != null) {
             for(ItemOptionCreateDto optionCreateDto : itemCreateDto.getOptions()) {
@@ -115,7 +118,8 @@ public class ItemService {
         item.UpdateDto(itemUpdateDto, category);
 
         // 새로운 이미지 파일 저장
-        imageS3Service.storeFiles(itemUpdateDto.getImages(), "images", item);
+        imageS3Service.storeFiles(itemUpdateDto.getImages(), "images", item, ItemImageFileStatus.THUMBNAIL);
+        imageS3Service.storeFiles(itemUpdateDto.getDetailImages(), "images", item, ItemImageFileStatus.DETAIL);
 
         // 삭제할 이미지 파일 처리
         if (itemUpdateDto.getDeleteImages() != null && !itemUpdateDto.getDeleteImages().isEmpty()) {

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/itemoption/dto/ItemOptionDto.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/itemoption/dto/ItemOptionDto.java
@@ -23,10 +23,11 @@ public class ItemOptionDto {
     private Integer discountPrice;
     private ItemStatus itemStatus;
     private List<ImageFile> imageFiles;
+    private List<ImageFile> detailImageFile;
 
 
     @Builder
-    public ItemOptionDto(Long itemId, Long itemOptionId, String content, String optionsInfo, String itemName, Integer optionPrice, Integer quantity, Integer totalPrice, Integer originalPrice, Integer discountRate, Integer discountPrice, String itemUID, ItemStatus itemStatus, List<ImageFile> imageFiles) {
+    public ItemOptionDto(Long itemId, Long itemOptionId, String content, String optionsInfo, String itemName, Integer optionPrice, Integer quantity, Integer totalPrice, Integer originalPrice, Integer discountRate, Integer discountPrice, String itemUID, ItemStatus itemStatus, List<ImageFile> imageFiles, List<ImageFile> detailImageFile) {
         this.itemId = itemId;
         this.itemOptionId = itemOptionId;
         this.content = content;
@@ -41,5 +42,6 @@ public class ItemOptionDto {
         this.itemUID = itemUID;
         this.itemStatus = itemStatus;
         this.imageFiles = imageFiles;
+        this.detailImageFile = detailImageFile;
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/itemoption/dto/ItemOptionDto.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/itemoption/dto/ItemOptionDto.java
@@ -2,6 +2,7 @@ package techit.gongsimchae.domain.groupbuying.itemoption.dto;
 
 import lombok.Builder;
 import lombok.Data;
+import techit.gongsimchae.domain.groupbuying.item.entity.ItemStatus;
 
 @Data
 public class ItemOptionDto {
@@ -17,10 +18,11 @@ public class ItemOptionDto {
     private Integer originalPrice;
     private Integer discountRate;
     private Integer discountPrice;
+    private ItemStatus itemStatus;
 
 
     @Builder
-    public ItemOptionDto(Long itemId, Long itemOptionId, String content, String optionsInfo, String itemName, Integer optionPrice, Integer quantity, Integer totalPrice, Integer originalPrice, Integer discountRate, Integer discountPrice, String itemUID) {
+    public ItemOptionDto(Long itemId, Long itemOptionId, String content, String optionsInfo, String itemName, Integer optionPrice, Integer quantity, Integer totalPrice, Integer originalPrice, Integer discountRate, Integer discountPrice, String itemUID, ItemStatus itemStatus) {
         this.itemId = itemId;
         this.itemOptionId = itemOptionId;
         this.content = content;
@@ -33,5 +35,6 @@ public class ItemOptionDto {
         this.discountRate = discountRate;
         this.discountPrice = discountPrice;
         this.itemUID = itemUID;
+        this.itemStatus = itemStatus;
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/itemoption/dto/ItemOptionDto.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/itemoption/dto/ItemOptionDto.java
@@ -2,7 +2,10 @@ package techit.gongsimchae.domain.groupbuying.itemoption.dto;
 
 import lombok.Builder;
 import lombok.Data;
+import techit.gongsimchae.domain.common.imagefile.entity.ImageFile;
 import techit.gongsimchae.domain.groupbuying.item.entity.ItemStatus;
+
+import java.util.List;
 
 @Data
 public class ItemOptionDto {
@@ -19,10 +22,11 @@ public class ItemOptionDto {
     private Integer discountRate;
     private Integer discountPrice;
     private ItemStatus itemStatus;
+    private List<ImageFile> imageFiles;
 
 
     @Builder
-    public ItemOptionDto(Long itemId, Long itemOptionId, String content, String optionsInfo, String itemName, Integer optionPrice, Integer quantity, Integer totalPrice, Integer originalPrice, Integer discountRate, Integer discountPrice, String itemUID, ItemStatus itemStatus) {
+    public ItemOptionDto(Long itemId, Long itemOptionId, String content, String optionsInfo, String itemName, Integer optionPrice, Integer quantity, Integer totalPrice, Integer originalPrice, Integer discountRate, Integer discountPrice, String itemUID, ItemStatus itemStatus, List<ImageFile> imageFiles) {
         this.itemId = itemId;
         this.itemOptionId = itemOptionId;
         this.content = content;
@@ -36,5 +40,6 @@ public class ItemOptionDto {
         this.discountPrice = discountPrice;
         this.itemUID = itemUID;
         this.itemStatus = itemStatus;
+        this.imageFiles = imageFiles;
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/itemoption/service/ItemOptionService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/itemoption/service/ItemOptionService.java
@@ -50,6 +50,7 @@ public class ItemOptionService {
                 .discountPrice(discountPrice)
                 .quantity(item.getGroupBuyingQuantity())
                 .itemUID(item.getUID())
+                .itemStatus(item.getItemStatus())
                 .build();
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/itemoption/service/ItemOptionService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/itemoption/service/ItemOptionService.java
@@ -3,6 +3,7 @@ package techit.gongsimchae.domain.groupbuying.itemoption.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import techit.gongsimchae.domain.common.imagefile.entity.ItemImageFileStatus;
 import techit.gongsimchae.domain.groupbuying.item.entity.Item;
 import techit.gongsimchae.domain.groupbuying.item.service.ItemService;
 import techit.gongsimchae.domain.groupbuying.itemoption.dto.ItemOptionDto;
@@ -51,7 +52,8 @@ public class ItemOptionService {
                 .quantity(item.getGroupBuyingQuantity())
                 .itemUID(item.getUID())
                 .itemStatus(item.getItemStatus())
-                .imageFiles(item.getImageFiles())
+                .imageFiles(item.getImageFiles().stream().filter(image -> image.getItemImageFileStatus().equals(ItemImageFileStatus.THUMBNAIL)).toList())
+                .detailImageFile(item.getImageFiles().stream().filter(image -> image.getItemImageFileStatus().equals(ItemImageFileStatus.DETAIL)).toList())
                 .build();
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/itemoption/service/ItemOptionService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/itemoption/service/ItemOptionService.java
@@ -51,6 +51,7 @@ public class ItemOptionService {
                 .quantity(item.getGroupBuyingQuantity())
                 .itemUID(item.getUID())
                 .itemStatus(item.getItemStatus())
+                .imageFiles(item.getImageFiles())
                 .build();
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/reviews/dto/ReviewResDtoWeb.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/reviews/dto/ReviewResDtoWeb.java
@@ -14,6 +14,7 @@ public class ReviewResDtoWeb {
     private String content;
     private Boolean secretStatus;
     private String images;
+    private String nickname;
 
     public ReviewResDtoWeb(Review review, String images){
         this.title = review.getTitle();
@@ -21,5 +22,6 @@ public class ReviewResDtoWeb {
         this.content = review.getContent();
         this.secretStatus = review.getSecretStatus().equals(SecretStatus.SECRET);
         this.images = images;
+        this.nickname = review.getUser().getNickname();
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/reviews/repository/ReviewRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/reviews/repository/ReviewRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import techit.gongsimchae.domain.common.user.entity.User;
 import techit.gongsimchae.domain.groupbuying.item.entity.Item;
 import techit.gongsimchae.domain.groupbuying.reviews.entity.Review;
+import techit.gongsimchae.domain.groupbuying.reviews.entity.SecretStatus;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findAllByUserId(Long userId);
@@ -14,4 +15,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Review findByUserIdAndUID(Long userId, String uid);
 
     Review findByUserIdAndItem(Long userId, Item item);
+
+    List<Review> findReviewsByItemAndSecretStatus(Item item, SecretStatus secretStatus);
 }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/reviews/service/ReviewService.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/reviews/service/ReviewService.java
@@ -14,10 +14,14 @@ import techit.gongsimchae.domain.groupbuying.item.repository.ItemRepository;
 import techit.gongsimchae.domain.groupbuying.reviews.dto.ReviewsReqDtoWeb;
 import techit.gongsimchae.domain.groupbuying.reviews.dto.ReviewResDtoWeb;
 import techit.gongsimchae.domain.groupbuying.reviews.entity.Review;
+import techit.gongsimchae.domain.groupbuying.reviews.entity.SecretStatus;
 import techit.gongsimchae.domain.groupbuying.reviews.repository.ReviewRepository;
 import techit.gongsimchae.global.dto.AccountDto;
 import techit.gongsimchae.global.exception.CustomWebException;
 import techit.gongsimchae.global.message.ErrorMessage;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @Transactional
@@ -56,5 +60,20 @@ public class ReviewService {
         );
         Review review = reviewRepository.findByUserIdAndItem(accountDto.getId(), item);
         review.update(reviewsReqDtoWeb);
+    }
+
+    public List<ReviewResDtoWeb> findReviewListByItemId(Long itemId) {
+
+        Item item = itemRepository.findById(itemId).orElseThrow(() -> new CustomWebException(ErrorMessage.ITEM_NOT_FOUND));
+
+        List<Review> reviewList = reviewRepository.findReviewsByItemAndSecretStatus(item, SecretStatus.NORMAL);
+        List<ReviewResDtoWeb> reviewResDtoWebList = new ArrayList<>();
+
+        for (Review review : reviewList) {
+            ImageFile imageFile = imageFileRepository.findByReview(review);
+            reviewResDtoWebList.add(new ReviewResDtoWeb(review, imageFile.getStoreFilename()));
+        }
+
+        return reviewResDtoWebList;
     }
 }

--- a/src/main/java/techit/gongsimchae/domain/web/groupbuying/CartController.java
+++ b/src/main/java/techit/gongsimchae/domain/web/groupbuying/CartController.java
@@ -33,7 +33,7 @@ public class CartController {
 
     @PostMapping("/update/{itemOptionId}")
     public ResponseEntity<Map<String, Object>> updateCartItem(@AuthenticationPrincipal PrincipalDetails userDetails,
-                                                              @PathVariable Long itemOptionId,
+                                                              @PathVariable("itemOptionId") Long itemOptionId,
                                                               @RequestBody Map<String, Integer> payload) {
         Long userId = userDetails.getAccountDto().getId();
         int quantity = payload.get("quantity");

--- a/src/main/java/techit/gongsimchae/domain/web/groupbuying/ItemController.java
+++ b/src/main/java/techit/gongsimchae/domain/web/groupbuying/ItemController.java
@@ -20,6 +20,7 @@ import techit.gongsimchae.domain.groupbuying.item.service.ItemService;
 import techit.gongsimchae.domain.groupbuying.itemoption.dto.ItemOptionDto;
 import techit.gongsimchae.domain.groupbuying.itemoption.service.ItemOptionService;
 import techit.gongsimchae.domain.groupbuying.orderitem.service.OrderItemService;
+import techit.gongsimchae.domain.groupbuying.reviews.service.ReviewService;
 import techit.gongsimchae.global.dto.PrincipalDetails;
 
 import java.util.List;
@@ -35,6 +36,7 @@ public class ItemController {
     private final EventCategoryService eventCategoryService;
     private final EventService eventService;
     private final OrderItemService orderItemService;
+    private final ReviewService reviewService;
 
     /**
      * 검색
@@ -124,6 +126,7 @@ public class ItemController {
 
         model.addAttribute("item",item);
         model.addAttribute("completionAmountItemCntDto", orderItemService.getCountCompletedOrderItemsWithItemId(id));
+        model.addAttribute("reviewResDtoWebList", reviewService.findReviewListByItemId(id));
 
         return "groupbuying/itemDetails";
     }

--- a/src/main/java/techit/gongsimchae/domain/web/groupbuying/ItemController.java
+++ b/src/main/java/techit/gongsimchae/domain/web/groupbuying/ItemController.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+import techit.gongsimchae.domain.common.imagefile.entity.ItemImageFileStatus;
 import techit.gongsimchae.domain.groupbuying.category.entity.Category;
 import techit.gongsimchae.domain.groupbuying.category.service.CategoryService;
 import techit.gongsimchae.domain.groupbuying.event.entity.Event;
@@ -80,7 +81,9 @@ public class ItemController {
         model.addAttribute("item", item);
         model.addAttribute("categories", categoryService.getAllCategories());
         model.addAttribute("isNew", false);
-        model.addAttribute("images", item.getImageFiles());
+        model.addAttribute("images", item.getImageFiles().stream().filter(image -> image.getItemImageFileStatus().equals(ItemImageFileStatus.THUMBNAIL)).toList());
+        model.addAttribute("detailImages", item.getImageFiles().stream().filter(image -> image.getItemImageFileStatus().equals(ItemImageFileStatus.DETAIL)).toList());
+
         return "admin/item/updateForm";
     }
 
@@ -91,7 +94,8 @@ public class ItemController {
         model.addAttribute("item", item);
         model.addAttribute("categories", categoryService.getAllCategories());
         model.addAttribute("isNew", false);
-        model.addAttribute("images", item.getImageFiles());
+        model.addAttribute("images", item.getImageFiles().stream().filter(image -> image.getItemImageFileStatus().equals(ItemImageFileStatus.THUMBNAIL)).toList());
+        model.addAttribute("detailImages", item.getImageFiles().stream().filter(image -> image.getItemImageFileStatus().equals(ItemImageFileStatus.DETAIL)).toList());
 
         return "admin/item/updateForm";
     }

--- a/src/main/java/techit/gongsimchae/domain/web/groupbuying/ItemController.java
+++ b/src/main/java/techit/gongsimchae/domain/web/groupbuying/ItemController.java
@@ -15,6 +15,7 @@ import techit.gongsimchae.domain.groupbuying.event.service.EventService;
 import techit.gongsimchae.domain.groupbuying.eventcategory.service.EventCategoryService;
 import techit.gongsimchae.domain.groupbuying.item.dto.*;
 import techit.gongsimchae.domain.groupbuying.item.entity.Item;
+import techit.gongsimchae.domain.groupbuying.item.entity.ItemStatus;
 import techit.gongsimchae.domain.groupbuying.item.service.ItemService;
 import techit.gongsimchae.domain.groupbuying.itemoption.dto.ItemOptionDto;
 import techit.gongsimchae.domain.groupbuying.itemoption.service.ItemOptionService;
@@ -69,7 +70,7 @@ public class ItemController {
     }
 
     @GetMapping("/admin/item/update/{id}")
-    public String showUpdateForm(@PathVariable Long id, Model model){
+    public String showUpdateForm(@PathVariable("id") Long id, Model model){
         Item item = itemService.getItemById(id);
         if(item == null) {
             return "redirect:/admin/item";
@@ -82,8 +83,22 @@ public class ItemController {
     }
 
     @PostMapping("/admin/item/update/{id}")
-    public String updateItem(@PathVariable Long id, @ModelAttribute ItemUpdateDto itemUpdateDto){
-        itemService.updateItem(id, itemUpdateDto);
+    public String updateItem(@PathVariable("id") Long id, @ModelAttribute ItemUpdateDto itemUpdateDto, Model model){
+        Item item = itemService.updateItem(id, itemUpdateDto);
+
+        model.addAttribute("item", item);
+        model.addAttribute("categories", categoryService.getAllCategories());
+        model.addAttribute("isNew", false);
+        model.addAttribute("images", item.getImageFiles());
+
+        return "admin/item/updateForm";
+    }
+
+    @PostMapping("/admin/item-status/update/{id}")
+    public String updateItemStatus(@PathVariable("id") Long id){
+
+        itemService.changeItemStatus(id, ItemStatus.공동구매_진행중);
+
         return "redirect:/admin/item";
     }
 

--- a/src/main/resources/static/css/admin/admin.css
+++ b/src/main/resources/static/css/admin/admin.css
@@ -205,3 +205,7 @@
 .form-container {
     margin-top: 20px;
 }
+
+body {
+    background-color: #f8f8f8;
+}

--- a/src/main/resources/static/css/admin/category.css
+++ b/src/main/resources/static/css/admin/category.css
@@ -43,7 +43,7 @@
 }
 
 /* 버튼 스타일 */
-.btn {
+.category-btn {
     padding: 10px 20px;
     border: none;
     border-radius: 5px;

--- a/src/main/resources/static/css/admin/createItemForm.css
+++ b/src/main/resources/static/css/admin/createItemForm.css
@@ -162,3 +162,26 @@
     padding: 5px;
     margin-left: 15px;
 }
+
+.custom-btn-add-option {
+    background-color: #cccccc; /* 기본 배경색 */
+    color: #ffffff; /* 흰색 텍스트 */
+    border: none;
+    border-radius: 5px;
+    height: 36px;
+    width: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: not-allowed; /* 기본 상태에서 클릭 불가능 */
+}
+
+.custom-btn-add-option.enabled {
+    background-color: #4CAF50; /* 연두색 배경 */
+    color: #ffffff; /* 흰색 텍스트 */
+    cursor: pointer; /* 활성화 시 클릭 가능 */
+}
+
+.custom-btn-add-option i {
+    color: inherit; /* 버튼 텍스트와 동일한 색상 */
+}

--- a/src/main/resources/static/css/admin/inquirylist.css
+++ b/src/main/resources/static/css/admin/inquirylist.css
@@ -75,7 +75,7 @@ select:focus {
     justify-content: flex-end;
 }
 
-.btn {
+.inquiry-btn {
     display: inline-block;
     padding: 10px 15px;
     font-size: 14px;

--- a/src/main/resources/static/css/admin/updateItemForm.css
+++ b/src/main/resources/static/css/admin/updateItemForm.css
@@ -168,3 +168,33 @@
     padding: 5px;
     margin-left: 15px;
 }
+
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0,0,0,0.4);
+}
+
+.modal-content {
+    background-color: #fff;
+    margin: 15% auto;
+    padding: 20px;
+    border: 1px solid #888;
+    width: 80%;
+    max-width: 400px;
+    text-align: center;
+}
+
+.modal-buttons {
+    margin-top: 20px;
+}
+
+.modal-buttons button {
+    margin: 0 10px;
+}

--- a/src/main/resources/static/css/groupbuying/cart.css
+++ b/src/main/resources/static/css/groupbuying/cart.css
@@ -178,3 +178,18 @@ body {
     color: #888;
     margin-top: 5px;
 }
+
+.cart-item.disabled {
+    opacity: 0.6;  /* 비활성화된 상품의 투명도 조절 */
+    pointer-events: none; /* 클릭 불가 처리 */
+}
+
+.cart-item.disabled .delete-item,
+.cart-item.disabled .item-checkbox {
+    cursor: not-allowed;
+}
+
+.cart-item.disabled .item-info .original-price {
+    color: red; /* 마감된 상품 표시를 위한 색상 */
+}
+

--- a/src/main/resources/static/css/groupbuying/cart.css
+++ b/src/main/resources/static/css/groupbuying/cart.css
@@ -2,7 +2,7 @@ body {
     font-family: 'Noto Sans KR', sans-serif;
     margin: 0;
     padding: 0;
-    background-color: #f8f8f8;
+    /*background-color: #f8f8f8;*/
 }
 
 .container {

--- a/src/main/resources/static/css/groupbuying/itemdetail.css
+++ b/src/main/resources/static/css/groupbuying/itemdetail.css
@@ -402,5 +402,142 @@ button#purchase-btn.closed {
     object-fit: cover;
 }
 
+/* 리뷰 섹션 스타일 추가 */
+.reviews-detail {
+    padding: 30px; /* 기존 다른 섹션들과 통일된 padding */
+    max-width: 1200px;
+    margin: 0 auto;
+    text-align: left; /* 리뷰 텍스트 정렬 변경 */
+    background-color: #fff;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    align-items: center;
+    justify-content: center;
+}
 
+.reviews-detail h4 {
+    margin-top: 0;
+    margin-bottom: 20px; /* 제목 아래 여백 */
+}
 
+/* 리뷰 카드 스타일 */
+.review-layout {
+    display: flex;
+    align-items: flex-start;
+    margin-bottom: 20px; /* 각 리뷰 카드 간격 */
+    padding-bottom: 20px; /* 각 카드 내부 패딩 */
+}
+
+/* 리뷰 이미지 설정 */
+.review-image {
+    flex-shrink: 0;
+    margin-right: 20px; /* 이미지와 텍스트 간격 */
+}
+
+.review-img {
+    width: 100px; /* 이미지 크기 조절 */
+    height: auto;
+    border-radius: 8px;
+    object-fit: cover;
+}
+
+/* 리뷰 제목 스타일 */
+.review-title {
+    font-size: 1.25rem;
+    margin-bottom: 10px;
+    color: #333;
+}
+
+/* 리뷰 별점 아이콘 */
+.review-rating {
+    margin-bottom: 15px;
+}
+
+.star-icon {
+    color: #fdd835; /* 노란색 별 아이콘 */
+    font-size: 20px;
+    margin-right: 2px;
+}
+
+/* 리뷰 내용 스타일 */
+.review-content .review-content-class {
+    margin: 0;
+}
+
+/* 비밀 리뷰 텍스트 */
+.text-muted {
+    margin-top: 10px;
+    font-size: 0.875rem;
+    color: #6c757d;
+}
+
+/* nick 스타일 수정 */
+.review-content p.nickname {
+    font-size: 0.875rem; /* 글자 크기 줄임 */
+    color: #6c757d; /* 회색 */
+}
+
+/* h4 태그 왼쪽 정렬 */
+.reviews-detail h4 {
+    margin-top: 0;
+    margin-bottom: 20px; /* 제목 아래 여백 */
+    text-align: center; /* 가운데 정렬 */
+}
+
+/* 프로그래스바 크기 조정 */
+.status-detail-container .progress {
+    background-color: #f0f0f0;
+    height: 20px; /* 높이 증가 */
+    width: 500px; /* 너비 증가 */
+    margin-bottom: 15px; /* 아래쪽 여백 추가 */
+}
+
+.progress-bar {
+    height: 100%; /* 프로그레스바 높이를 부모에 맞춤 */
+}
+
+/* 리뷰 섹션 스타일 추가 */
+.review-layout {
+    display: flex;
+    align-items: flex-start;
+    margin-bottom: 20px; /* 각 리뷰 카드 간격 */
+    padding-bottom: 20px; /* 각 카드 내부 패딩 */
+    position: relative; /* 모달을 위한 설정 */
+}
+
+/* 모달 창 스타일 */
+.modal {
+    display: none; /* 초기에는 숨김 */
+    position: fixed;
+    z-index: 1000; /* 가장 위에 오도록 설정 */
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0, 0, 0, 0.8); /* 배경 어둡게 */
+}
+
+.modal-content {
+    margin: 10% auto;
+    display: block;
+    max-width: 80%;
+}
+
+.modal-content img {
+    width: 500px;
+    height: auto;
+}
+
+.modal-close {
+    position: absolute;
+    top: 10px;
+    right: 25px;
+    color: #fff;
+    font-size: 35px;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.review-writer {
+    color: #BDBDBD;
+}

--- a/src/main/resources/static/css/groupbuying/itemdetail.css
+++ b/src/main/resources/static/css/groupbuying/itemdetail.css
@@ -343,3 +343,10 @@ body {
     padding-top: 10px;
     border-top: 1px solid #ddd;
 }
+
+button#purchase-btn.closed {
+    background-color: #6c757d;
+    color: #fff;
+    cursor: not-allowed;
+    border: none;
+}

--- a/src/main/resources/static/css/groupbuying/itemdetail.css
+++ b/src/main/resources/static/css/groupbuying/itemdetail.css
@@ -350,3 +350,54 @@ button#purchase-btn.closed {
     cursor: not-allowed;
     border: none;
 }
+
+.product-detail-image-slider {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    max-width: 600px;
+    margin: 0 140px;
+}
+
+.main-image-container {
+    width: 100%;
+    height: 400px;
+    margin-bottom: 20px;
+    border: 2px solid #ddd;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+}
+
+.main-image {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}
+
+.thumbnail-container {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+}
+
+.thumbnail {
+    width: 80px;
+    height: 80px;
+    border: 2px solid transparent;
+    cursor: pointer;
+}
+
+.thumbnail.active {
+    border-color: #555555; /* 진한 회색 테두리 색상 */
+}
+
+.thumbnail-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+
+

--- a/src/main/resources/static/css/groupbuying/itemdetail.css
+++ b/src/main/resources/static/css/groupbuying/itemdetail.css
@@ -117,8 +117,11 @@ body {
     padding: 30px; /* 패딩 증가로 내부 여백 확대 */
     max-width: 1200px;
     margin: 0 auto;
-    background-color: #f9f9f9;
     text-align: center;
+    background-color: #fff;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    align-items: center;
+    justify-content: center;
 }
 
 .product-description-detail h4, .reviews-detail h4, .inquiries-detail h4 {

--- a/src/main/resources/static/css/mypage.css
+++ b/src/main/resources/static/css/mypage.css
@@ -3,7 +3,7 @@ body {
     font-family: 'Noto Sans KR', sans-serif;
     margin: 0;
     padding: 0;
-    background-color: #f8f8f8;
+    /*background-color: #f8f8f8;*/
 }
 
 .mypage-container {

--- a/src/main/resources/static/css/navbar.css
+++ b/src/main/resources/static/css/navbar.css
@@ -2,7 +2,7 @@ body {
     font-family: 'Noto Sans KR', sans-serif;
     margin: 0;
     padding: 0;
-    background-color: #f8f8f8 !important;
+    /*background-color: #f8f8f8 !important;*/
 }
 .custom-container{
     background-color: white !important;

--- a/src/main/resources/static/css/navbar.css
+++ b/src/main/resources/static/css/navbar.css
@@ -9,9 +9,8 @@ body {
 }
 .container-nav{
     background-color: #ffffff;
-}
-nav {
-    margin: 0 180px;
+    width: 1050px;
+    margin: 0 auto;
 }
 
 .navbar {
@@ -107,8 +106,8 @@ nav {
 }
 
 .nav-list-a {
-    margin-right: 3rem !important;
-    margin-left: 6rem !important;
+    margin-right: 4rem !important;
+    margin-left: 4rem !important;
 }
 
 .form-style {

--- a/src/main/resources/static/css/portion/portioningMain.css
+++ b/src/main/resources/static/css/portion/portioningMain.css
@@ -168,7 +168,6 @@ ul {
 }
 
 .search-btn {
-    height: 50px;
     border: none; /* 연두색 테두리 추가 */
     background-color: #4CAF50;
     color: #ffffff;

--- a/src/main/resources/static/js/admin/createItemForm.js
+++ b/src/main/resources/static/js/admin/createItemForm.js
@@ -52,18 +52,78 @@ function beforeSubmit() {
 
     // DataTransfer 객체를 사용하여 모든 파일을 추가
     const dataTransfer = new DataTransfer();
+    const detailImagesDataTransfer = new DataTransfer();
+
     selectedFiles.forEach(file => {
         dataTransfer.items.add(file);
+    });
+
+    selectedDetailFiles.forEach(file => {
+        detailImagesDataTransfer.items.add(file);
     });
 
     // 기존 파일 인풋 필드를 가져와 파일들을 설정
     const fileInput = document.getElementById('images');
     fileInput.files = dataTransfer.files;
+
+    const detailFileInput = document.getElementById('detailImages');
+    detailFileInput.files = detailImagesDataTransfer.files;
 }
 
 // 파일 선택창을 열기 위한 함수
 function triggerFileInput() {
     document.getElementById('images').click();  // 이미지 선택 창 열기
+}
+
+function triggerDetailFileInput() {
+    document.getElementById('detailImages').click();  // 이미지 선택 창 열기
+}
+
+let selectedDetailFiles = []; // 모든 선택된 파일을 저장할 배열
+
+// 이미지 미리보기 함수
+function previewDetailImages(event) {
+    const files = Array.from(event.target.files);  // 새로운 파일을 배열로 변환
+    selectedDetailFiles = selectedDetailFiles.concat(files);  // 새로운 파일을 기존 배열에 추가
+
+    updateDetailImagePreview();  // 미리보기 업데이트
+}
+
+function updateDetailImagePreview() {
+    const previewContainer = document.getElementById('image-preview-container2');
+    previewContainer.innerHTML = '';  // 기존 미리보기 이미지 초기화
+
+    selectedDetailFiles.forEach((file, index) => {
+        const reader = new FileReader();
+
+        reader.onload = function(e) {
+            const wrapper = document.createElement('div');
+            wrapper.classList.add('image-preview-wrapper');
+
+            const img = document.createElement('img');
+            img.src = e.target.result;
+            img.classList.add('image-preview');
+
+            const deleteButton = document.createElement('button');
+            deleteButton.innerHTML = 'X';
+            deleteButton.classList.add('image-delete-button');
+            deleteButton.onclick = function() {
+                removeDetailImage(index);
+            };
+
+            wrapper.appendChild(img);
+            wrapper.appendChild(deleteButton);
+            previewContainer.appendChild(wrapper);
+        };
+
+        reader.readAsDataURL(file);  // 파일을 읽어서 미리보기로 표시
+    });
+}
+
+// 이미지 제거 함수
+function removeDetailImage(index) {
+    selectedDetailFiles.splice(index, 1);  // 해당 인덱스의 파일을 배열에서 제거
+    updateDetailImagePreview();  // 미리보기 업데이트
 }
 
 // 옵션 추가 및 제거 기능
@@ -96,6 +156,9 @@ function addOptionField() {
         // 입력 필드 초기화
         document.getElementById('optionContent').value = '';
         document.getElementById('optionPrice').value = '';
+
+        // 옵션 추가 버튼 스타일 초기화
+        toggleAddOptionButton();
     } else {
         alert('옵션명과 가격을 모두 입력하세요.');
     }
@@ -105,3 +168,80 @@ function removeOption(button) {
     const optionSet = button.closest('.input-option-set');
     optionSet.remove();
 }
+
+document.addEventListener('DOMContentLoaded', function() {
+    const groupBuyingLimitTimeInput = document.getElementById('groupBuyingLimitTime');
+    const addOptionButton = document.querySelector('.custom-btn-add-option');
+    const optionContentInput = document.getElementById('optionContent');
+    const optionPriceInput = document.getElementById('optionPrice');
+
+    // 오늘 날짜로 초기화
+    function setInitialDateTime() {
+        const now = new Date();
+        now.setSeconds(59);
+        now.setMilliseconds(0);
+        const formattedDate = now.toISOString().slice(0, 16); // "YYYY-MM-DDTHH:MM"
+        groupBuyingLimitTimeInput.value = formattedDate;
+        groupBuyingLimitTimeInput.min = formattedDate; // 과거 날짜 선택 방지
+    }
+
+    setInitialDateTime();
+
+    groupBuyingLimitTimeInput.addEventListener('input', function() {
+        const date = new Date(groupBuyingLimitTimeInput.value);
+        date.setMinutes(59);
+        date.setSeconds(59);
+        groupBuyingLimitTimeInput.value = date.toISOString().slice(0, 16);
+    });
+
+    const originalPriceInput = document.getElementById('originalPrice');
+    const discountRateInput = document.getElementById('discountRate');
+    const pointAccumulationRateInput = document.getElementById('pointAccumulationRate');
+    const discountedPriceDisplay = document.getElementById('discountedPrice');
+    const accumulatedPointsDisplay = document.getElementById('accumulatedPoints');
+
+    function updateDiscountedPrice() {
+        const originalPrice = parseFloat(originalPriceInput.value) || 0;
+        const discountRate = parseFloat(discountRateInput.value) || 0;
+        const discountedPrice = originalPrice * (1 - discountRate / 100);
+        discountedPriceDisplay.textContent = `할인가 : ${discountedPrice.toLocaleString()}원`;
+    }
+
+    function updateAccumulatedPoints() {
+        const originalPrice = parseFloat(originalPriceInput.value) || 0;
+        const pointRate = parseFloat(pointAccumulationRateInput.value) || 0;
+        const accumulatedPoints = originalPrice * (pointRate / 100);
+        accumulatedPointsDisplay.textContent = `포인트 적립 금액 : ${accumulatedPoints.toLocaleString()}원`;
+    }
+
+    originalPriceInput.addEventListener('input', function() {
+        updateDiscountedPrice();
+        updateAccumulatedPoints();
+    });
+
+    discountRateInput.addEventListener('input', function() {
+        if (parseFloat(discountRateInput.value) > 99) {
+            discountRateInput.value = 99;
+        }
+        updateDiscountedPrice();
+    });
+
+    pointAccumulationRateInput.addEventListener('input', function() {
+        if (parseFloat(pointAccumulationRateInput.value) > 99) {
+            pointAccumulationRateInput.value = 99;
+        }
+        updateAccumulatedPoints();
+    });
+
+    // 옵션 추가 버튼 활성화 제어
+    function toggleAddOptionButton() {
+        if (optionContentInput.value.trim() !== '' && optionPriceInput.value.trim() !== '') {
+            addOptionButton.classList.add('enabled');
+        } else {
+            addOptionButton.classList.remove('enabled');
+        }
+    }
+
+    optionContentInput.addEventListener('input', toggleAddOptionButton);
+    optionPriceInput.addEventListener('input', toggleAddOptionButton);
+});

--- a/src/main/resources/static/js/admin/updateItemForm.js
+++ b/src/main/resources/static/js/admin/updateItemForm.js
@@ -58,6 +58,51 @@ document.getElementById('mainForm').addEventListener('submit', function(e) {
     e.target.submit();
 });
 
+function triggerDetailFileInput() {
+    document.getElementById('detailImages').click();  // 이미지 선택 창 열기
+}
+
+let selectedDetailFiles = []; // 모든 선택된 파일을 저장할 배열
+
+// 이미지 미리보기 함수
+function previewDetailImages(event) {
+    const container = document.getElementById('image-preview-container2');
+    const files = event.target.files;
+
+    for (let i = 0; i < files.length; i++) {
+        const file = files[i];
+        const reader = new FileReader();
+
+        reader.onload = function(e) {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'image-preview-wrapper';
+
+            const img = document.createElement('img');
+            img.src = e.target.result;
+            img.className = 'image-preview';
+
+            const deleteButton = document.createElement('button');
+            deleteButton.innerHTML = 'X';
+            deleteButton.className = 'image-delete-button';
+            deleteButton.onclick = function() {
+                container.removeChild(wrapper);
+            };
+
+            wrapper.appendChild(img);
+            wrapper.appendChild(deleteButton);
+            container.appendChild(wrapper);
+        }
+
+        reader.readAsDataURL(file);
+    }
+}
+
+// 이미지 제거 함수
+function removeDetailImage(index) {
+    selectedDetailFiles.splice(index, 1);  // 해당 인덱스의 파일을 배열에서 제거
+    updateDetailImagePreview();  // 미리보기 업데이트
+}
+
 function addOptionField() {
     const container = document.getElementById('added-options');
     const currentOptionContent = document.getElementById('optionContent').value.trim();

--- a/src/main/resources/static/js/admin/updateItemForm.js
+++ b/src/main/resources/static/js/admin/updateItemForm.js
@@ -47,8 +47,15 @@ function updateDeleteImagesInput() {
 }
 
 // 폼 제출 전 deleteImages 입력 필드 업데이트
-document.querySelector('form').addEventListener('submit', function(e) {
-    updateDeleteImagesInput();
+document.getElementById('mainForm').addEventListener('submit', function(e) {
+    e.preventDefault(); // 기존 폼 제출을 막음
+    updateDeleteImagesInput(); // 이미지 삭제 업데이트
+
+    // 수정 완료 알림 표시
+    alert("상품 내용이 수정되었습니다. 공동구매 재진행하기 위해서는 옆의 '공동구매 재진행' 버튼을 누르셔야 합니다.");
+
+    // 알림 후 폼 제출
+    e.target.submit();
 });
 
 function addOptionField() {
@@ -101,3 +108,77 @@ function updateOptionIndexes() {
 document.addEventListener('DOMContentLoaded', function() {
     updateOptionIndexes();
 });
+
+function validateGroupBuyingTime() {
+    let limitTimeField = document.getElementById('groupBuyingLimitTime');
+    let limitTime = new Date(limitTimeField.value);
+    let currentTime = new Date();
+
+    // 제한 시간이 현재 시간과 같거나 과거라면 알림창 표시
+    if (limitTime <= currentTime) {
+        alert('공동구매 제한 시간을 다시 한 번 확인해주세요. 미래 시간으로 설정해야 합니다.');
+    } else {
+        // 공동구매 제한 시간이 유효하면 모달창 띄움
+        showModal();
+    }
+}
+
+// 공동구매 제한 시간을 시, 분, 초 중 시만 수정 가능하게 설정
+document.addEventListener('DOMContentLoaded', function() {
+    let limitTimeField = document.getElementById('groupBuyingLimitTime');
+
+    if (limitTimeField.value) {
+        let originalTime = new Date(limitTimeField.value);
+        // 초 단위에서 '분'과 '초'를 59분 58초로 고정
+        originalTime.setMinutes(59);
+        originalTime.setSeconds(59);
+        limitTimeField.value = originalTime.toISOString().slice(0, 16); // '시'까지만 표시
+    }
+
+    limitTimeField.addEventListener('input', function() {
+        let date = new Date(this.value);
+        date.setMinutes(59);
+        date.setSeconds(59);
+        this.value = date.toISOString().slice(0, 16); // 시까지만 표시
+    });
+});
+
+document.getElementById('group-buying-restart-form').addEventListener('submit', function (e) {
+    e.preventDefault(); // 폼 제출을 막음
+
+    let limitTimeField = document.getElementById('groupBuyingLimitTime');
+    let limitTime = new Date(limitTimeField.value);
+    let currentTime = new Date();
+
+    // 제한 시간이 유효하면 모달 창 표시
+    if (limitTime > currentTime) {
+        showModal();
+    } else {
+        alert('공동구매 제한 시간을 다시 한 번 확인해주세요. 미래 시간으로 설정해야 합니다.');
+    }
+});
+
+function showModal() {
+    const modal = document.getElementById('confirmationModal');
+    const confirmYes = document.getElementById('confirmYes');
+    const confirmNo = document.getElementById('confirmNo');
+
+    modal.style.display = "block"; // 모달 표시
+
+    confirmYes.onclick = function () {
+        modal.style.display = "none"; // 모달 숨기기
+        document.getElementById('group-buying-restart-form').submit(); // 폼 제출
+    };
+
+    confirmNo.onclick = function () {
+        modal.style.display = "none"; // 모달 숨기기
+    };
+}
+
+// 모달 외부 클릭 시 닫기
+window.onclick = function (event) {
+    const modal = document.getElementById('confirmationModal');
+    if (event.target == modal) {
+        modal.style.display = "none";
+    }
+};

--- a/src/main/resources/static/js/groupbuying/cart.js
+++ b/src/main/resources/static/js/groupbuying/cart.js
@@ -34,10 +34,11 @@ document.addEventListener('DOMContentLoaded', function() {
     // 장바구니 아이템 업데이트
     function updateCartItem(container) {
         const cartItem = container.closest('.cart-item');
-        if (!cartItem) {
-            console.error('Cart item not found');
+        if (!cartItem || cartItem.classList.contains('disabled')) {
+            console.error('Cannot update a closed cart item');
             return;
         }
+
         const itemOptionId = cartItem.dataset.itemOptionId;
         const quantity = container.querySelector('input').value;
 

--- a/src/main/resources/static/js/groupbuying/itemdetail.js
+++ b/src/main/resources/static/js/groupbuying/itemdetail.js
@@ -1,4 +1,20 @@
 document.addEventListener('DOMContentLoaded', function() {
+    const mainImage = document.getElementById('main-image');
+    const thumbnails = document.querySelectorAll('.thumbnail');
+
+    thumbnails.forEach(thumbnail => {
+        thumbnail.addEventListener('click', function() {
+            // 현재 선택된 썸네일을 강조 표시하고, 이전 선택된 썸네일은 강조 해제
+            thumbnails.forEach(thumb => thumb.classList.remove('active'));
+            this.classList.add('active');
+
+            // 큰 이미지 변경
+            const newSrc = this.querySelector('.thumbnail-image').src;
+            mainImage.src = newSrc;
+        });
+    });
+
+
     const optionSelect = document.getElementById('product-options');
     const totalPriceEl = document.getElementById('total-price');
     const selectedOptionsEl = document.getElementById('selected-options');

--- a/src/main/resources/static/js/groupbuying/itemdetail.js
+++ b/src/main/resources/static/js/groupbuying/itemdetail.js
@@ -151,4 +151,35 @@ document.addEventListener('DOMContentLoaded', function() {
     document.addEventListener('click', changeQuantity);
     document.addEventListener('click', removeOption);
     addToCartForm.addEventListener('submit', addToCart);
+
+    // 모달 관련 코드 추가
+    const modal = document.createElement('div');
+    modal.className = 'modal';
+    modal.innerHTML = `
+        <span class="modal-close">&times;</span>
+        <div class="modal-content">
+            <img src="" alt="리뷰 이미지">
+        </div>
+    `;
+    document.body.appendChild(modal);
+
+    const modalImg = modal.querySelector('img');
+    const modalClose = modal.querySelector('.modal-close');
+
+    document.querySelectorAll('.review-img').forEach(img => {
+        img.addEventListener('click', function() {
+            modal.style.display = 'block';
+            modalImg.src = this.src;
+        });
+    });
+
+    modalClose.addEventListener('click', function() {
+        modal.style.display = 'none';
+    });
+
+    modal.addEventListener('click', function(event) {
+        if (event.target === modal) {
+            modal.style.display = 'none';
+        }
+    });
 });

--- a/src/main/resources/templates/admin/category/categoryList.html
+++ b/src/main/resources/templates/admin/category/categoryList.html
@@ -12,7 +12,7 @@
     <div class="col-12">
       <div class="d-flex justify-content-between align-items-center">
         <h1 class="section-title">카테고리 관리</h1>
-        <button class="btn btn-point-color" id="openModalBtn">카테고리 생성</button>
+        <button class="category-btn btn-point-color" id="openModalBtn">카테고리 생성</button>
       </div>
       <table class="table table-striped">
         <thead>

--- a/src/main/resources/templates/admin/inquiry/inquiryList.html
+++ b/src/main/resources/templates/admin/inquiry/inquiryList.html
@@ -27,7 +27,7 @@
                     <div th:text="'작성일: ' + ${#temporals.format(inquiry.createDate, 'yyyy-MM-dd HH:mm:ss')}"></div>
                 </div>
                 <div class="inquiry-actions">
-                    <a class="btn btn-outline-primary"
+                    <a class="inquiry-btn btn-outline-primary"
                        th:href="@{/admin/inquires/reply/{id}(id=${inquiry.UID})}">상세보기</a>
                 </div>
             </div>

--- a/src/main/resources/templates/admin/item/createItemForm.html
+++ b/src/main/resources/templates/admin/item/createItemForm.html
@@ -67,18 +67,20 @@
 
             <div class="form-group">
                 <label for="discountRate" class="form-label">할인율</label>
-                <input type="number" class="form-control" id="discountRate" th:field="*{discountRate}" step="0.01" required/>
+                <input type="number" class="form-control" id="discountRate" th:field="*{discountRate}" step="0.01" min="0" max="99" required />
                 <div class="invalid-feedback">
                     할인율을 입력해주세요.
                 </div>
+                <div id="discountedPrice" class="form-text">할인가 : 0원</div> <!-- 할인가를 표시할 영역 추가 -->
             </div>
 
             <div class="form-group">
                 <label for="pointAccumulationRate" class="form-label">포인트 적립률</label>
-                <input type="number" class="form-control" id="pointAccumulationRate" th:field="*{pointAccumulationRate}" step="0.01" required/>
+                <input type="number" class="form-control" id="pointAccumulationRate" th:field="*{pointAccumulationRate}" step="0.01" min="0" max="99" required />
                 <div class="invalid-feedback">
                     포인트 적립률을 입력해주세요.
                 </div>
+                <div id="accumulatedPoints" class="form-text">포인트 적립 금액 : 0원</div> <!-- 포인트 적립 금액을 표시할 영역 추가 -->
             </div>
 
             <div class="form-group">
@@ -91,7 +93,7 @@
 
             <div class="form-group">
                 <label for="groupBuyingLimitTime" class="form-label">공동구매 제한 시간</label>
-                <input type="datetime-local" class="form-control" id="groupBuyingLimitTime" th:field="*{groupBuyingLimitTime}"/>
+                <input type="datetime-local" class="form-control" id="groupBuyingLimitTime" th:field="*{groupBuyingLimitTime}" />
             </div>
 
             <div class="form-group">
@@ -106,6 +108,15 @@
                 <div class="invalid-feedback">
                     카테고리를 선택해주세요.
                 </div>
+            </div>
+
+            <div class="form-group" style="width: 600px">
+                <label for="detailImages" class="form-label">상품 상세 설명</label>
+                <div class="custom-file-upload" onclick="triggerDetailFileInput()"> <!-- 이미지 업로드 박스 전체 클릭 이벤트 추가 -->
+                    <input type="file" class="form-control-file" id="detailImages" name="detailImages" multiple onchange="previewDetailImages(event)" style="display: none;" />
+                    <i class="fas fa-plus"></i> <!-- + 아이콘만 남겨둠 -->
+                </div>
+                <div id="image-preview-container2" class="image-preview-container"></div>
             </div>
 
             <div class="form-group">

--- a/src/main/resources/templates/admin/item/item.html
+++ b/src/main/resources/templates/admin/item/item.html
@@ -43,7 +43,7 @@
                 <td th:text="${item.createDate}"></td>
                 <td th:text="${item.category?.name}"></td>
                 <td>
-                    <a th:if="${item.deleteStatus == 0}" th:href="@{/admin/item/edit/{id}(id=${item.id})}" class="btn-custom btn-edit">수정</a>
+                    <a th:if="${item.deleteStatus == 0}" th:href="@{/admin/item/update/{id}(id=${item.id})}" class="btn-custom btn-edit">수정</a>
                 </td>
                 <td>
                     <form th:if="${item.deleteStatus.equals(0)}" th:action="@{/admin/item/delete}" method="post">

--- a/src/main/resources/templates/admin/item/updateForm.html
+++ b/src/main/resources/templates/admin/item/updateForm.html
@@ -26,7 +26,7 @@
                 </div>
                 <div id="image-preview-container" class="image-preview-container">
                     <!-- 서버에서 제공한 이미지 URL을 통해 이미지를 렌더링 -->
-                    <div th:each="imageFile, iterStat : ${item.imageFiles}" class="image-preview-wrapper">
+                    <div th:each="imageFile, iterStat : ${images}" class="image-preview-wrapper">
                         <img th:src="@{${imageFile.storeFilename}}" class="image-preview"/>
                         <button type="button" class="image-delete-button"  th:onclick="'removeExistingImage(' + ${imageFile.id} + ', this)'">X</button>
                     </div>
@@ -126,6 +126,21 @@
                 </select>
                 <div class="invalid-feedback">
                     카테고리를 선택해주세요.
+                </div>
+            </div>
+
+            <div class="form-group" style="width: 600px">
+                <label for="detailImages" class="form-label">상품 상세 설명</label>
+                <div class="custom-file-upload" onclick="triggerDetailFileInput()"> <!-- 이미지 업로드 박스 전체 클릭 이벤트 추가 -->
+                    <input type="file" class="form-control-file" id="detailImages" name="detailImages" multiple onchange="previewDetailImages(event)" style="display: none;" />
+                    <i class="fas fa-plus"></i> <!-- + 아이콘만 남겨둠 -->
+                </div>
+                <div id="image-preview-container2" class="image-preview-container">
+                    <!-- 서버에서 제공한 이미지 URL을 통해 이미지를 렌더링 -->
+                    <div th:each="imageFile, iterStat : ${detailImages}" class="image-preview-wrapper">
+                        <img th:src="@{${imageFile.storeFilename}}" class="image-preview"/>
+                        <button type="button" class="image-delete-button"  th:onclick="'removeExistingImage(' + ${imageFile.id} + ', this)'">X</button>
+                    </div>
                 </div>
             </div>
 

--- a/src/main/resources/templates/admin/item/updateForm.html
+++ b/src/main/resources/templates/admin/item/updateForm.html
@@ -14,7 +14,7 @@
 
     <div class="form-container">
         <h1 class="mb-4 section-title">상품 수정</h1>
-        <form th:action="@{/admin/item/update/{id}(id=${item.id})}" th:object="${item}" method="post" enctype="multipart/form-data" class="needs-validation input-form-container" novalidate>
+        <form id="mainForm" th:action="@{/admin/item/update/{id}(id=${item.id})}" th:object="${item}" method="post" enctype="multipart/form-data" class="needs-validation input-form-container" novalidate>
 
             <div class="form-group" style="width: 600px">
                 <label for="images" class="form-label">이미지 파일들</label>
@@ -133,6 +133,21 @@
                 <button type="submit" class="btn btn-point-color float-right" style="color: #ffffff">수정</button>
             </div>
         </form>
+
+        <form th:action="@{/admin/item-status/update/{id}(id=${item.id})}" method="post" id="group-buying-restart-form" style="display: inline;">
+            <button type="button" class="btn btn-secondary float-right mr-2" style="color: #ffffff" onclick="validateGroupBuyingTime()">공동구매 재시작</button>
+        </form>
+
+        <!-- 모달 창 추가 -->
+        <div id="confirmationModal" class="modal">
+            <div class="modal-content">
+                <p>누르면 상품이 메인 화면에 노출됩니다. 공동구매를 다시 진행하시겠습니까?</p>
+                <div class="modal-buttons">
+                    <button id="confirmYes" class="btn btn-primary">예</button>
+                    <button id="confirmNo" class="btn btn-secondary">아니오</button>
+                </div>
+            </div>
+        </div>
     </div>
 
     <script src="/js/admin/updateItemForm.js"></script>

--- a/src/main/resources/templates/groupbuying/cart.html
+++ b/src/main/resources/templates/groupbuying/cart.html
@@ -21,30 +21,34 @@
                     </div>
                     <ul class="item-list">
                         <li class="cart-item" th:each="item : ${cartItems}" th:data-item-option-id="${item.itemOptionId}">
-                            <input type="checkbox" name="selectedItemOptionId" th:value="${item.itemOptionId}" class="item-checkbox" />
+                            <!-- 공동구매 마감이 아닌 경우에만 체크박스 표시 -->
+                            <th:block th:if="${item.itemStatus.toString() != '공동구매_마감'}">
+                                <input type="checkbox" name="selectedItemOptionId" th:value="${item.itemOptionId}" class="item-checkbox" />
+                            </th:block>
                             <div class="item-info">
                                 <h3 class="item-info-name" th:text="${item.itemName}">[브랜드] 상품명</h3>
                                 <p class="item-option-info" th:text="${item.itemName + ' (' + item.content + ')'}">상품명 (옵션 내용)</p>
-                                <div class="quantity">
+
+                                <!-- 수량 조절 버튼은 공동구매 마감 시 숨김 처리 -->
+                                <div class="quantity" th:if="${item.itemStatus.toString() != '공동구매_마감'}">
                                     <button type="button" class="minus-btn">-</button>
                                     <input type="number" th:value="${item.quantity}" min="1">
                                     <button type="button" class="plus-btn">+</button>
                                 </div>
+
                                 <div class="price-container">
                                     <div class="price-progress-container">
-                                        <span class="original-price" th:text="${#numbers.formatDecimal(item.originalPrice, 0, 'COMMA', 0, 'POINT')} + '원'">원래 가격</span>
-                                        <div class="progress-container">
-                                            <div class="custom-progress">
-                                                <div class="custom-progress-bar" role="progressbar"
-                                                     th:style="'width: ' + ${(item.groupBuyingQuantity / 100.0) * 100} + '%'"
-                                                     th:aria-valuenow="${item.groupBuyingQuantity}"
-                                                     aria-valuemin="0" aria-valuemax="100">
-                                                    <span th:text="${item.groupBuyingQuantity + '%'}"></span>
-                                                </div>
-                                            </div>
-                                        </div>
+                                        <!-- 가격 부분에 마감된 상품 표시 -->
+                                        <span class="original-price"
+                                              th:if="${item.itemStatus.toString() == '공동구매_마감'}"
+                                              th:text="'마감된 상품'"></span>
+                                        <span class="original-price"
+                                              th:if="${item.itemStatus.toString() != '공동구매_마감'}"
+                                              th:text="${#numbers.formatDecimal(item.originalPrice, 0, 'COMMA', 0, 'POINT')} + '원'">원래 가격</span>
                                     </div>
-                                    <div class="discount-info">
+
+                                    <!-- 할인 정보 숨기기 -->
+                                    <div class="discount-info" th:if="${item.itemStatus.toString() != '공동구매_마감'}">
                                         <span class="discount-rate" th:text="${item.discountRate} + '%'">할인율</span>
                                         <span class="discount-price"
                                               th:with="discountPrice=${item.originalPrice * (100 - item.discountRate) / 100}"
@@ -53,6 +57,7 @@
                                     </div>
                                 </div>
                             </div>
+
                             <button type="button" class="delete-item">×</button>
                         </li>
                     </ul>

--- a/src/main/resources/templates/groupbuying/itemDetails.html
+++ b/src/main/resources/templates/groupbuying/itemDetails.html
@@ -85,10 +85,29 @@
 </section>
 <section class="reviews-detail">
     <h4>후기</h4>
-    <p>여기에 상품 후기가 들어갑니다. 고객들이 작성한 후기를 포함시킬 수 있습니다.</p>
+    <div th:each="review : ${reviewResDtoWebList}" class="card mb-3">
+        <div class="card-body">
+            <div class="review-layout">
+                <!-- 이미지 섹션 -->
+                <div class="review-image">
+                    <img th:src="@{${review.images}}" alt="리뷰 이미지" class="review-img">
+                </div>
+                <!-- 리뷰 내용 섹션 -->
+                <div class="review-content">
+                    <h5 th:text="${review.title}" class="review-title">리뷰 제목</h5>
+                    <p th:text="${review.nickname}" class="review-writer"></p>
+                    <div class="review-rating">
+                        <span th:each="star : ${#numbers.sequence(1, review.starPoint)}">
+                            <i class="fas fa-star star-icon"></i>
+                        </span>
+                    </div>
+                    <p th:text="${review.content}" class="review-content-class">리뷰 내용</p>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <!-- CSRF 토큰을 메타 태그로 삽입 -->
-
     <script th:fragment="pick">
         document.addEventListener('DOMContentLoaded', function () {
             const wishlistBtn = document.getElementById('wishlist-btn');

--- a/src/main/resources/templates/groupbuying/itemDetails.html
+++ b/src/main/resources/templates/groupbuying/itemDetails.html
@@ -77,7 +77,11 @@
 </section>
 <section class="product-description-detail">
     <h4>상품 설명</h4>
-    <p>여기에 상세 설명이 들어갑니다. 제품의 특징, 사용 방법, 주의 사항 등을 포함시킬 수 있습니다.</p>
+    <div class="detail-item-images">
+        <div th:each="imageFile : ${item[0].detailImageFile}">
+            <img th:src="@{${imageFile.storeFilename}}" alt="상세 이미지" style="width: 800px; height: auto; max-width: 100%" />
+        </div>
+    </div>
 </section>
 <section class="reviews-detail">
     <h4>후기</h4>

--- a/src/main/resources/templates/groupbuying/itemDetails.html
+++ b/src/main/resources/templates/groupbuying/itemDetails.html
@@ -38,7 +38,14 @@
                     <button class="custom-btn-outline-secondary" id="wishlist-btn" th:data-item-id="${item[0].itemUID}">
                         <i id="wishlist-icon" class="bi"></i> 찜하기
                     </button>
-                    <button class="custom-btn-success" id="purchase-btn" type="submit">장바구니에 담기</button>
+
+                    <button class="custom-btn-success"
+                            id="purchase-btn"
+                            type="submit"
+                            th:classappend="${item[0].itemStatus.toString() == '공동구매_마감'} ? 'closed' : ''"
+                            th:disabled="${item[0].itemStatus.toString() == '공동구매_마감'}"
+                            th:text="${item[0].itemStatus.toString() == '공동구매_마감'} ? '마감된 상품입니다' : '장바구니에 담기'">
+                    </button>
                 </div>
             </div>
         </div>
@@ -47,11 +54,14 @@
 <div class="separator-detail"></div>
 <section class="status-detail-container">
     <div class="progress">
-        <div class="progress-bar bg-success" role="progressbar"
-             th:style="'width:' + (${completionAmountItemCntDto.completionAmountCnt} / ${item[0].quantity} * 100) + '%;'"
-             aria-valuenow="[[${completionAmountItemCntDto.completionAmountCnt}]]"
+
+        <!-- 프로그레스바 -->
+        <div class="progress-bar bg-success"
+             role="progressbar"
+             th:style="${item[0].itemStatus.toString() == '공동구매_마감'} ? 'width: 100%' : 'width:' + (${completionAmountItemCntDto.completionAmountCnt} / ${item[0].quantity} * 100) + '%;'"
+             th:aria-valuenow="${item[0].itemStatus.toString() == '공동구매_마감'} ? ${item[0].quantity} : ${completionAmountItemCntDto.completionAmountCnt}"
              aria-valuemin="0"
-             aria-valuemax="[[${item[0].quantity}]]">
+             th:aria-valuemax="${item[0].quantity}">
         </div>
     </div>
     <span>목표 수량: <span th:text="${item[0].quantity}"></span> / 달성량: <span th:text="${completionAmountItemCntDto.completionAmountCnt}"></span></span>

--- a/src/main/resources/templates/groupbuying/itemDetails.html
+++ b/src/main/resources/templates/groupbuying/itemDetails.html
@@ -11,11 +11,20 @@
 </head>
 <body>
 <section class="product-detail-section">
-<!--    <div class="product-detail-image" th:each="itemImage : ${item.getImageUrls()}">-->
-<!--        <img th:src="${itemImage}" alt="no image"/>-->
+    <div class="product-detail-image-slider">
+        <div class="main-image-container">
+            <img th:src="${item[0].getImageFiles()[0].storeFilename}" alt="메인 이미지" class="main-image" id="main-image">
+        </div>
+        <div class="thumbnail-container">
+            <div class="thumbnail" th:each="itemImage, iterStat : ${item[0].getImageFiles()}"
+                 th:classappend="${iterStat.index == 0} ? 'active' : ''">
+                <img th:src="${itemImage.storeFilename}" alt="상품 이미지" class="thumbnail-image"/>
+            </div>
+        </div>
+    </div>
     <form id="addToCartForm" th:action="@{/product/cart/add}" method="post">
         <div class="product-detail-info">
-            <h3 class="product-detail-title" th:text="${item[0].itemName}">에어프라이어 용 미니 돈까스</h3>
+            <h3 class="product-detail-title" th:text="${item[0].itemName}"></h3>
 
             <div class="btn-detail-container">
                 <select class="form-select" id="product-options" aria-label="상품 선택">
@@ -52,7 +61,7 @@
     </form>
 </section>
 <div class="separator-detail"></div>
-<section class="status-detail-container">
+<section class="status-detail-container product-detail-section">
     <div class="progress">
 
         <!-- 프로그레스바 -->

--- a/src/main/resources/templates/layout/navbar.html
+++ b/src/main/resources/templates/layout/navbar.html
@@ -73,7 +73,7 @@
         <div class="navbar-links nav-container mt-3 text-center">
 
         <div class="d-flex justify-content-center mt-2">
-            <div class="navbar-menu">카테고리
+            <div class="navbar-menu nav-list-a">카테고리
                 <ul class="dropdown-menu">
                     <li th:each="category : ${categories}">
                         <a class="dropdown-item" th:text="${category.name}"
@@ -84,17 +84,18 @@
             <a th:href="@{/collection-groups/new-item}" class="btn btn-link nav-list-a">신상품</a>
             <a th:href="@{/collection-groups/best-item}" class="btn btn-link nav-list-a">베스트</a>
             <a th:href="@{/event}" class="btn btn-link nav-list-a">이벤트</a>
+            <a sec:authorize="hasRole('ADMIN')" th:href="@{/admin/users}" class="btn btn-link nav-list-a">관리자 페이지</a>
             <div sec:authorize="hasRole('USER')">
-                <a th:href="@{/mypage/inquiry/list}" class="btn btn-link nav-list-a">1:1 문의</a>
+<!--                <a th:href="@{/mypage/inquiry/list}" class="btn btn-link nav-list-a">1:1 문의</a>-->
             </div>
         </div>
-        <div sec:authorize="isAnonymous()">
-            <a> </a>
-        </div>
+<!--        <div sec:authorize="isAnonymous()">-->
+<!--            <a> </a>-->
+<!--        </div>-->
 
-            <div sec:authorize="hasRole('ADMIN')" class="text-end-admin">
-                <a th:href="@{/admin/users}" class="btn btn-link nav-list-a">관리자 페이지</a>
-            </div>
+<!--            <div sec:authorize="hasRole('ADMIN')" class="text-end-admin">-->
+<!--                <a th:href="@{/admin/users}" class="btn btn-link nav-list-a">관리자 페이지</a>-->
+<!--            </div>-->
         </div>
     </nav>
 </div>
@@ -171,24 +172,28 @@
 
         </div>
         <div class="navbar-links nav-container mt-3 text-center">
-            <div class="navbar-menu">
-                <a th:href="@{/}" class="btn btn-link nav-list-a">소분 글 리스트</a>
-            </div>
+<!--            <div class="navbar-menu">-->
+<!--                <a th:href="@{/}" class="btn btn-link nav-list-a">소분 글 리스트</a>-->
+<!--            </div>-->
             <div class="d-flex justify-content-center mt-2">
                 <a th:href="@{/portioning/write}" class="btn btn-link nav-list-a">글 작성</a>
+<!--                <a sec:authorize="hasRole('USER')" th:href="@{/mypage/inquiry/list}" class="btn btn-link nav-list-a">1:1 문의</a>-->
+                <a sec:authorize="hasRole('USER')" href="#" onclick="openKeywordPopup(); return false;" class="btn btn-link nav-list-a">키워드 등록</a>
+                <a sec:authorize="hasRole('ADMIN')" th:href="@{/admin/users}" class="btn btn-link nav-list-a">관리자 페이지</a>
+
             </div>
-            <div sec:authorize="isAnonymous()">
-                <a> </a>
-            </div>
-            <div sec:authorize="hasRole('USER')">
-                <a th:href="@{/mypage/inquiry/list}" class="btn btn-link nav-list-a">1:1 문의</a>
-            </div>
-            <div sec:authorize="hasRole('USER')">
-                <a href="#" onclick="openKeywordPopup(); return false;" class="btn btn-link nav-list-a">키워드 등록</a>
-            </div>
-            <div sec:authorize="hasRole('ADMIN')" class="text-end">
-                <a th:href="@{/admin/users}" class="btn btn-link nav-list-a">관리자 페이지</a>
-            </div>
+<!--            <div sec:authorize="isAnonymous()">-->
+<!--                <a> </a>-->
+<!--            </div>-->
+<!--            <div sec:authorize="hasRole('USER')">-->
+<!--                <a th:href="@{/mypage/inquiry/list}" class="btn btn-link nav-list-a">1:1 문의</a>-->
+<!--            </div>-->
+<!--            <div sec:authorize="hasRole('USER')">-->
+<!--                <a href="#" onclick="openKeywordPopup(); return false;" class="btn btn-link nav-list-a">키워드 등록</a>-->
+<!--            </div>-->
+<!--            <div sec:authorize="hasRole('ADMIN')" class="text-end">-->
+<!--                <a th:href="@{/admin/users}" class="btn btn-link nav-list-a">관리자 페이지</a>-->
+<!--            </div>-->
         </div>
     </nav>
 </div>


### PR DESCRIPTION
## Overview

- 공동구매 재진행 할 때 수정 페이지에서 마감 기한을 미래 시점으로 바꿔야 재진행 될 수 있도록 구현해보았습니다.
- 상품 등록할 때 상품 상세 설명 이미지도 같이 등록 할 수 있도록 하였습니다.
- 상품 상세페이지에서 이미지 제대로 띄우고 상품 상세 설명 이미지도 띄우게 하였습니다. 상품과 관련된 리뷰들도 화면 아래에 띄웠습니다.
- 네비게이션 바 CSS 조정 완료하였습니다.

## Change Log

- 상품 수정 코드를 일부 변경했습니다. 원래 코드는 상품 수정 완료 시 관리자 상품 리스트로 리다이렉트 됐지만 수정된 코드는 공동구매 재진행 로직을 위해 이동하지 않고 현재 페이지에 그대로 머무릅니다.
- imageFile 엔티티에 enum 필드가 새로 추가되었습니다.

## To Reviewer

- imageFile의 ItemImageFileStatus 필드 때문에 기존의 상품 데이터로 상품 상세 페이지 접속하면 오류가 뜰 것 입니다. 
- update image_file set item_image_file_status = 'THUMBNAIL' where item_id is not null;
- 로 imageFile 테이블 업데이트 하시면 됩니다

## Issue Tags

- #
