### PR TITLE
Fix: 찜 목록 사진 추가, 기본배송지 수정

### DIFF
--- a/src/main/java/techit/gongsimchae/domain/common/address/repository/AddressRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/common/address/repository/AddressRepository.java
@@ -14,9 +14,6 @@ public interface AddressRepository extends JpaRepository<Address, Long> {
 
     Optional<Address> findByUID(String id);
 
-    @Query("select a from Address a where a.defaultAddressStatus = 'PRIMARY'")
-    Optional<Address> findDefaultAddress();
-
     @Query("select a from Address a join a.user u where u.id = :id and a.defaultAddressStatus = 'PRIMARY'")
     Optional<Address> findDefaultAddressByUser(@Param("id") Long userId);
 }

--- a/src/main/java/techit/gongsimchae/domain/common/address/service/AddressService.java
+++ b/src/main/java/techit/gongsimchae/domain/common/address/service/AddressService.java
@@ -35,7 +35,7 @@ public class AddressService {
     public void addAddress(AddressCreateReqDtoWeb addressCreateReqDtoWeb, PrincipalDetails principalDetails) {
         User user = userRepository.findByLoginId(principalDetails.getUsername()).orElseThrow(() -> new CustomWebException(ErrorMessage.USER_NOT_FOUND));
         addressCreateReqDtoWeb.applySetting(user.getName(), user.getPhoneNumber());
-        unsetAsDefault();
+        unsetAsDefault(user.getId());
         Address address = new Address(addressCreateReqDtoWeb, user, DefaultAddressStatus.PRIMARY);
 
         addressRepository.save(address);
@@ -45,7 +45,7 @@ public class AddressService {
     public void addAddress(AddressCreateReqDtoWeb addressCreateReqDtoWeb, Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new CustomWebException(ErrorMessage.USER_NOT_FOUND));
         addressCreateReqDtoWeb.applySetting(user.getName(), user.getPhoneNumber());
-        unsetAsDefault();
+        unsetAsDefault(userId);
         Address address = new Address(addressCreateReqDtoWeb, user, DefaultAddressStatus.PRIMARY);
 
         addressRepository.save(address);
@@ -74,14 +74,14 @@ public class AddressService {
     }
 
     @Transactional
-    public void changeDefaultAddress(String id) {
-        unsetAsDefault();
+    public void changeDefaultAddress(String id, Long userId) {
+        unsetAsDefault(userId);
         Address address = addressRepository.findByUID(id).orElseThrow(() -> new CustomWebException(ErrorMessage.ADDRESS_NOT_FOUND));
         address.setDefaultAddress();
     }
 
-    private void unsetAsDefault() {
-        Optional<Address> defaultAddress = addressRepository.findDefaultAddress();
+    private void unsetAsDefault(Long userId) {
+        Optional<Address> defaultAddress = addressRepository.findDefaultAddressByUser(userId);
         if (defaultAddress.isPresent()) {
             Address address = defaultAddress.get();
             address.unsetDefaultAddress();

--- a/src/main/java/techit/gongsimchae/domain/common/imagefile/repository/ImageFileRepository.java
+++ b/src/main/java/techit/gongsimchae/domain/common/imagefile/repository/ImageFileRepository.java
@@ -1,7 +1,10 @@
 package techit.gongsimchae.domain.common.imagefile.repository;
 
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import techit.gongsimchae.domain.common.imagefile.entity.ImageFile;
 import techit.gongsimchae.domain.common.inquiry.entity.Inquiry;
@@ -17,7 +20,8 @@ public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
 
     List<ImageFile> findAllByItemIn(List<Item> recentItems);
 
-    ImageFile findByItem(Item item);
+    @Query("select if from ImageFile if join fetch if.item i where i.id=:id and if.itemImageFileStatus = 'THUMBNAIL' ")
+    Optional<ImageFile> findByItemThumbnail(Long id);
 
     List<ImageFile> findAllByItem(Item item);
 

--- a/src/main/java/techit/gongsimchae/domain/common/wishlist/service/WishListService.java
+++ b/src/main/java/techit/gongsimchae/domain/common/wishlist/service/WishListService.java
@@ -5,6 +5,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import techit.gongsimchae.domain.common.imagefile.entity.ImageFile;
+import techit.gongsimchae.domain.common.imagefile.repository.ImageFileRepository;
 import techit.gongsimchae.domain.common.user.entity.User;
 import techit.gongsimchae.domain.common.user.repository.UserRepository;
 import techit.gongsimchae.domain.common.wishlist.dto.SubdivisionWishListRespDto;
@@ -31,6 +33,7 @@ public class WishListService {
     private final ItemRepository itemRepository;
     private final UserRepository userRepository;
     private final SubdivisionRepository subdivisionRepository;
+    private final ImageFileRepository imageFileRepository;
 
 
     @Transactional(readOnly = true)
@@ -62,9 +65,15 @@ public class WishListService {
      * 찜목록에 넣은 아이템 가져오기
      */
     public Page<ItemRespDtoWeb> getPickItems(PrincipalDetails principalDetails, Pageable pageable) {
-        return wishListRepository.findWishListsItemByUserIdAndSubdivisionIsNullOrderByCreateDateDesc(principalDetails.getAccountDto().getId(),
+        Page<ItemRespDtoWeb> results = wishListRepository.findWishListsItemByUserIdAndSubdivisionIsNullOrderByCreateDateDesc(principalDetails.getAccountDto().getId(),
                         pageable)
                 .map(wishList -> new ItemRespDtoWeb(wishList.getItem()));
+
+        for (ItemRespDtoWeb result : results) {
+            Optional<ImageFile> _imageFile = imageFileRepository.findByItemThumbnail(result.getId());
+            _imageFile.ifPresent(file -> result.setImageUrl(file.getStoreFilename()));
+        }
+        return results;
 
     }
 

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/dto/ItemRespDtoWeb.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/dto/ItemRespDtoWeb.java
@@ -36,6 +36,7 @@ public class ItemRespDtoWeb {
     private String itemBannerImage;
     private Long participateCount;
     private Integer progressbarWidth;
+    private String imageUrl;
 
 
     public ItemRespDtoWeb(Item item) {

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/dto/ItemRespDtoWeb.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/dto/ItemRespDtoWeb.java
@@ -37,6 +37,7 @@ public class ItemRespDtoWeb {
     private Long participateCount;
     private Integer progressbarWidth;
     private String imageUrl;
+    private Integer categoryStatus;
 
 
     public ItemRespDtoWeb(Item item) {

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/repository/ItemCustomRepositoryImpl.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/repository/ItemCustomRepositoryImpl.java
@@ -100,6 +100,7 @@ public class ItemCustomRepositoryImpl implements ItemCustomRepository {
                         item.pointAccumulationRate, item.groupBuyingLimitTime, item.groupBuyingQuantity,
                         item.UID, item.cumulativeSalesVolume, item.reviewCount))
                 .from(item)
+                .where(item.deleteStatus.eq(0))
                 .orderBy(item.createDate.desc())
                 .limit(pageable.getPageSize())
                 .offset(pageable.getOffset())
@@ -128,6 +129,7 @@ public class ItemCustomRepositoryImpl implements ItemCustomRepository {
 
         Long size = queryFactory.select(item.count())
                 .from(item)
+                .where(item.deleteStatus.eq(0))
                 .fetchOne();
         return new PageImpl<>(results, pageable, size.intValue());
     }

--- a/src/main/java/techit/gongsimchae/domain/groupbuying/item/repository/ItemCustomRepositoryImpl.java
+++ b/src/main/java/techit/gongsimchae/domain/groupbuying/item/repository/ItemCustomRepositoryImpl.java
@@ -35,7 +35,8 @@ public class ItemCustomRepositoryImpl implements ItemCustomRepository {
         List<ItemRespDtoWeb> results = queryFactory.select(Projections.fields(ItemRespDtoWeb.class,
                         item.id, item.name, item.intro, item.originalPrice, item.discountRate,
                         item.pointAccumulationRate, item.groupBuyingQuantity, item.groupBuyingLimitTime,
-                        item.createDate, category.name.as("categoryName"), item.deleteStatus))
+                        item.createDate, category.name.as("categoryName"), item.deleteStatus,
+                        category.categoryStatus))
                 .from(item)
                 .join(item.category, category)
                 .where(adminSearch(form))

--- a/src/main/java/techit/gongsimchae/domain/web/common/UserController.java
+++ b/src/main/java/techit/gongsimchae/domain/web/common/UserController.java
@@ -159,8 +159,8 @@ public class UserController {
     }
 
     @PostMapping("/change/default/address/{id}")
-    public ResponseEntity<?> changeDefaultAddress(@PathVariable("id") String id) {
-        addressService.changeDefaultAddress(id);
+    public ResponseEntity<?> changeDefaultAddress(@PathVariable("id") String id, @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        addressService.changeDefaultAddress(id, principalDetails.getAccountDto().getId());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/resources/static/css/mypage/picklist.css
+++ b/src/main/resources/static/css/mypage/picklist.css
@@ -174,9 +174,11 @@
     background-color: #fff;
     border-radius: 10px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    display: flex;
     overflow: hidden;
     transition: transform 0.2s ease;
     width: 800px;
+    justify-content: space-around;
 }
 
 .custom-picklist-item-card:hover {
@@ -185,8 +187,8 @@
 
 /* Image styling */
 .custom-picklist-image-wrapper {
-    width: 100%;
-    height: 200px;
+    width: 150px;
+    height: 150px;
     overflow: hidden;
 }
 

--- a/src/main/resources/templates/admin/item/item.html
+++ b/src/main/resources/templates/admin/item/item.html
@@ -57,7 +57,7 @@
                         <button type="submit" class="btn-custom btn-delete">삭제</button>
                     </form>
                     <form th:if="${item.deleteStatus.equals(1)}" th:action="@{/admin/item/restore}" method="post"
-                          th:attr="data-category-status=${item.category.categoryStatus}">
+                          th:attr="data-category-status=${item.categoryStatus}">
                         <input type="hidden" th:value="${item.id}" name="id"/>
                         <button type="button" class="btn-custom btn-restore" onclick="checkCategoryStatus(this)">복구</button>
                     </form>

--- a/src/main/resources/templates/mypage/pickList.html
+++ b/src/main/resources/templates/mypage/pickList.html
@@ -11,8 +11,8 @@
         <div class="row" th:each="item : ${items}">
             <div class="col-md-6 col-lg-4 mb-4">
                 <div class="custom-picklist-item-card">
-                    <div class="custom-picklist-image-wrapper" th:if="${item.getImageUrls != null}" th:with="image=${item.getImageUrls.getFirst()}">
-                        <img th:src="${image.getStoreFileName()}" class="custom-picklist-image" alt="상품 이미지">
+                    <div class="custom-picklist-image-wrapper" th:if="${item.imageUrl != null}" >
+                        <img th:src="${item.imageUrl}" class="custom-picklist-image" alt="상품 이미지">
                     </div>
                     <div class="custom-picklist-item-details">
                         <h4 class="custom-picklist-item-title">


### PR DESCRIPTION
## Overview

- Fix: 찜 목록 사진 추가, 기본배송지 수정

## Change Log

-  찜목록에 아이템 이미지가 없던걸 있게 만들었습니다.
- 기본배송지를 없앨때 모든 주소엔티티에서 기본배송지로 있던걸 찾아서 변경하는게 아니라 user에 속한 address를 찾아서 기본배송지로 변경되도록 바꿨습니다.

## To Reviewer

-

## Issue Tags

- #
